### PR TITLE
Expose `egui::Response` and JSON path in `JsonTreeResponse`

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -176,7 +176,7 @@ impl Show for CopyToClipboardExample {
                         ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
                             ui.set_width(150.0);
 
-                            if path != ""
+                            if !path.is_empty()
                                 && ui
                                     .add(Button::new("Copy property path").frame(false))
                                     .clicked()

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -215,7 +215,7 @@ impl Show for CopyToClipboardExample {
         let tree = JsonTree::new(self.title, &self.value);
         let response = tree.show(ui, DefaultExpand::None);
 
-        if let Some((response, path)) = response.response {
+        if let Some((response, path)) = response.inner {
             if response.secondary_clicked() {
                 println!("{}", path);
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -175,16 +175,23 @@ impl Show for CopyToClipboardExample {
                     Frame::popup(ui.style()).show(ui, |ui| {
                         ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
                             ui.set_width(150.0);
-                            if ui
-                                .add(Button::new("Copy property path").frame(false))
-                                .clicked()
+
+                            if path != "/"
+                                && ui
+                                    .add(Button::new("Copy property path").frame(false))
+                                    .clicked()
                             {
                                 ui.output_mut(|o| o.copied_text = path.clone());
                                 should_close_popup = true;
                             }
 
                             if ui.add(Button::new("Copy contents").frame(false)).clicked() {
-                                if let Some(val) = self.value.pointer(path) {
+                                let val = if path == "/" {
+                                    Some(&self.value)
+                                } else {
+                                    self.value.pointer(path)
+                                };
+                                if let Some(val) = val {
                                     if let Ok(pretty_str) = serde_json::to_string_pretty(val) {
                                         ui.output_mut(|o| o.copied_text = pretty_str);
                                     }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -176,23 +176,20 @@ impl Show for CopyToClipboardExample {
                         ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
                             ui.set_width(150.0);
 
-                            if path != "/"
+                            if path != ""
                                 && ui
                                     .add(Button::new("Copy property path").frame(false))
                                     .clicked()
                             {
+                                println!("{}", path);
                                 ui.output_mut(|o| o.copied_text = path.clone());
                                 should_close_popup = true;
                             }
 
                             if ui.add(Button::new("Copy contents").frame(false)).clicked() {
-                                let val = if path == "/" {
-                                    Some(&self.value)
-                                } else {
-                                    self.value.pointer(path)
-                                };
-                                if let Some(val) = val {
+                                if let Some(val) = self.value.pointer(path) {
                                     if let Ok(pretty_str) = serde_json::to_string_pretty(val) {
+                                        println!("{}", pretty_str);
                                         ui.output_mut(|o| o.copied_text = pretty_str);
                                     }
                                 }
@@ -217,8 +214,6 @@ impl Show for CopyToClipboardExample {
 
         if let Some((response, path)) = response.inner {
             if response.secondary_clicked() {
-                println!("{}", path);
-
                 self.popup_response = Some((
                     response
                         .interact_pointer_pos()

--- a/src/delimiters.rs
+++ b/src/delimiters.rs
@@ -5,13 +5,13 @@ pub struct Delimiters {
 }
 
 pub const ARRAY_DELIMITERS: Delimiters = Delimiters {
-    collapsed: "[ ... ]",
+    collapsed: "[...]",
     opening: "[",
     closing: "]",
 };
 
 pub const OBJECT_DELIMITERS: Delimiters = Delimiters {
-    collapsed: "{ ... }",
+    collapsed: "{...}",
     opening: "{",
     closing: "}",
 };

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 
-use egui::{collapsing_header::CollapsingState, Id, Ui};
+use egui::{collapsing_header::CollapsingState, Id, Response, Ui};
 
 /// The response from showing a [`JsonTree`](crate::JsonTree).
 pub struct JsonTreeResponse {
+    pub response: Option<(Response, String)>,
     pub(crate) collapsing_state_ids: HashSet<Id>,
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,7 +9,7 @@ pub struct JsonTreeResponse {
     ///
     /// The JSON pointer is an identifier composed of each subsequent object key or array index, e.g. `"/foo/bar/0"`.
     ///
-    /// For anything hovered within a collapsed top-level array/object, the JSON pointer string will refer to the entire JSON document, i.e. `"/"`.
+    /// For anything hovered within a collapsed top-level array/object, the JSON pointer string will refer to the entire JSON document, i.e. `""`.
     pub inner: Option<(Response, String)>,
     pub(crate) collapsing_state_ids: HashSet<Id>,
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -4,7 +4,13 @@ use egui::{collapsing_header::CollapsingState, Id, Response, Ui};
 
 /// The response from showing a [`JsonTree`](crate::JsonTree).
 pub struct JsonTreeResponse {
-    pub response: Option<(Response, String)>,
+    /// If any object key, array index, or value was hovered, this `Option` will contain the [`Response`](egui::Response)
+    /// and JSON pointer string.
+    ///
+    /// The JSON pointer is an identifier composed of each subsequent object key or array index, e.g. `"/foo/bar/0"`.
+    ///
+    /// For anything hovered within a collapsed top-level array/object, the JSON pointer string will refer to the entire JSON document, i.e. `"/"`.
+    pub inner: Option<(Response, String)>,
     pub(crate) collapsing_state_ids: HashSet<Id>,
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -12,6 +12,8 @@ pub struct JsonTreeStyle {
     pub number_color: Color32,
     pub string_color: Color32,
     pub highlight_color: Color32,
+    /// The text color for array brackets, object braces, colons and commas.
+    pub punctuation_color: Color32,
 }
 
 impl Default for JsonTreeStyle {
@@ -24,6 +26,7 @@ impl Default for JsonTreeStyle {
             number_color: Color32::from_rgb(181, 199, 166),
             string_color: Color32::from_rgb(194, 146, 122),
             highlight_color: Color32::from_rgba_premultiplied(72, 72, 72, 50),
+            punctuation_color: Color32::from_gray(140),
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -196,6 +196,7 @@ fn show_base_value(
     key_response.or(value_response)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn show_expandable(
     ui: &mut Ui,
     path_segments: &mut Vec<String>,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -271,9 +271,7 @@ fn show_expandable(
                                 );
 
                                 if let Some(value_response) = value_response {
-                                    let mut path_str = "/".to_string();
-                                    path_str.push_str(&path_segments.join("/"));
-                                    *response = Some((value_response, path_str));
+                                    *response = Some((value_response, "/".to_string()));
                                 }
                             }
                             JsonTreeValue::Expandable(_, expandable_type) => {
@@ -286,9 +284,7 @@ fn show_expandable(
 
                                 if let Some(key_response) = key_response {
                                     if key_response.hovered() {
-                                        let mut path_str = "/".to_string();
-                                        path_str.push_str(&path_segments.join("/"));
-                                        *response = Some((key_response, path_str));
+                                        *response = Some((key_response, "/".to_string()));
                                     }
                                 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -122,7 +122,7 @@ impl JsonTree {
     ) {
         match self.value {
             JsonTreeValue::Base(value_str, value_type) => {
-                let key_texts = get_key_text(&self.style, &self.parent, search_term);
+                let key_texts = get_key_texts(&self.style, &self.parent, search_term);
                 let base_value_response = ui
                     .horizontal_wrapped(|ui| {
                         ui.spacing_mut().item_spacing.x = 0.0;
@@ -179,7 +179,7 @@ fn show_base_value(
     value_type: &BaseValueType,
     search_term: &Option<SearchTerm>,
 ) -> Option<Response> {
-    let key_response = render_texts(ui, key_texts);
+    let key_response = show_texts(ui, key_texts);
 
     let mut texts = vec![];
 
@@ -191,7 +191,7 @@ fn show_base_value(
         style.highlight_color,
     );
 
-    let value_response = render_texts(ui, texts);
+    let value_response = show_texts(ui, texts);
 
     key_response.or(value_response)
 }
@@ -242,7 +242,7 @@ fn show_expandable(
                                 // Don't show array indices when the array is collapsed.
                                 vec![]
                             } else {
-                                get_key_text(
+                                get_key_texts(
                                     style,
                                     &Some(Parent::new(key.to_owned(), expandable.expandable_type)),
                                     search_term,
@@ -265,7 +265,7 @@ fn show_expandable(
                                 }
                             }
                             JsonTreeValue::Expandable(_, expandable_type) => {
-                                let key_response = render_texts(ui, key_texts);
+                                let key_response = show_texts(ui, key_texts);
 
                                 if let Some(key_response) = key_response {
                                     *response = Some((key_response, "".to_string()));
@@ -288,8 +288,8 @@ fn show_expandable(
 
                     ui.label(delimiters.closing);
                 } else {
-                    let key_texts = get_key_text(style, &expandable.parent, search_term);
-                    let key_response = render_texts(ui, key_texts);
+                    let key_texts = get_key_texts(style, &expandable.parent, search_term);
+                    let key_response = show_texts(ui, key_texts);
 
                     if let Some(key_response) = key_response {
                         let mut path_str = "/".to_string();
@@ -358,7 +358,7 @@ fn show_expandable(
     }
 }
 
-fn get_key_text(
+fn get_key_texts(
     style: &JsonTreeStyle,
     parent: &Option<Parent>,
     search_term: &Option<SearchTerm>,
@@ -367,11 +367,11 @@ fn get_key_text(
         Some(Parent {
             key,
             expandable_type: ExpandableType::Array,
-        }) => format_array_idx(key, style.array_idx_color),
+        }) => get_array_idx_texts(key, style.array_idx_color),
         Some(Parent {
             key,
             expandable_type: ExpandableType::Object,
-        }) => format_object_key(
+        }) => get_object_key_texts(
             key,
             style.object_key_color,
             search_term,
@@ -381,7 +381,7 @@ fn get_key_text(
     }
 }
 
-fn format_object_key(
+fn get_object_key_texts(
     key_str: &str,
     color: Color32,
     search_term: &Option<SearchTerm>,
@@ -397,7 +397,7 @@ fn format_object_key(
     texts
 }
 
-fn format_array_idx(idx_str: &str, color: Color32) -> Vec<RichText> {
+fn get_array_idx_texts(idx_str: &str, color: Color32) -> Vec<RichText> {
     vec![
         RichText::new(idx_str).color(color),
         RichText::new(": ").monospace(),
@@ -435,7 +435,7 @@ fn add_texts_with_highlighting(
     texts.push(RichText::new(text_str).color(text_color));
 }
 
-fn render_texts(ui: &mut Ui, texts: Vec<RichText>) -> Option<Response> {
+fn show_texts(ui: &mut Ui, texts: Vec<RichText>) -> Option<Response> {
     texts
         .into_iter()
         .map(|text| ui.add(Label::new(text.monospace()).sense(Sense::click_and_drag())))

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -237,8 +237,6 @@ fn show_expandable(
                     let entries_len = expandable.entries.len();
 
                     for (idx, (key, elem)) in expandable.entries.iter().enumerate() {
-                        path_segments.push(key.clone());
-
                         let key_texts =
                             if matches!(expandable.expandable_type, ExpandableType::Array) {
                                 // Don't show array indices when the array is collapsed.
@@ -263,14 +261,14 @@ fn show_expandable(
                                 );
 
                                 if let Some(value_response) = value_response {
-                                    *response = Some((value_response, "/".to_string()));
+                                    *response = Some((value_response, "".to_string()));
                                 }
                             }
                             JsonTreeValue::Expandable(_, expandable_type) => {
                                 let key_response = render_texts(ui, key_texts);
 
                                 if let Some(key_response) = key_response {
-                                    *response = Some((key_response, "/".to_string()));
+                                    *response = Some((key_response, "".to_string()));
                                 }
 
                                 let nested_delimiters = match expandable_type {
@@ -286,8 +284,6 @@ fn show_expandable(
                         } else {
                             ui.monospace(", ");
                         }
-
-                        path_segments.pop();
                     }
 
                     ui.label(delimiters.closing);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -438,7 +438,7 @@ fn add_texts_with_highlighting(
 fn render_texts(ui: &mut Ui, texts: Vec<RichText>) -> Option<Response> {
     texts
         .into_iter()
-        .map(|text| ui.add(Label::new(text.monospace()).sense(Sense::click())))
+        .map(|text| ui.add(Label::new(text.monospace()).sense(Sense::click_and_drag())))
         .reduce(|acc, next| acc.union(next))
         .filter(Response::hovered)
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -233,6 +233,8 @@ fn show_expandable(
                     let entries_len = expandable.entries.len();
 
                     for (idx, (key, elem)) in expandable.entries.iter().enumerate() {
+                        path_segments.push(key.clone());
+
                         let key_texts =
                             if matches!(expandable.expandable_type, ExpandableType::Array) {
                                 // Don't show array indices when the array is collapsed.
@@ -260,7 +262,6 @@ fn show_expandable(
                                     if value_response.hovered() {
                                         let mut path_str = "/".to_string();
                                         path_str.push_str(&path_segments.join("/"));
-                                        path_str.push_str(key);
                                         *response = Some((value_response, path_str));
                                     }
                                 }
@@ -277,7 +278,6 @@ fn show_expandable(
                                     if key_response.hovered() {
                                         let mut path_str = "/".to_string();
                                         path_str.push_str(&path_segments.join("/"));
-                                        path_str.push_str(key);
                                         *response = Some((key_response, path_str));
                                     }
                                 }
@@ -295,6 +295,8 @@ fn show_expandable(
                         } else {
                             ui.monospace(", ");
                         }
+
+                        path_segments.pop();
                     }
 
                     ui.label(delimiters.closing);

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -106,7 +106,7 @@ impl JsonTree {
         });
 
         JsonTreeResponse {
-            response,
+            inner: response,
             collapsing_state_ids: path_id_map.into_values().collect(),
         }
     }


### PR DESCRIPTION
- Adds `pub inner: Option<(Response, String)>` field to `JsonTreeResponse`.
-  Adds `CopyToClipboard` example to demonstrate use of the Response and path for copying JSON paths and values to clipboard.
- Shows all labels as monospace.
- Adds `pub punctuation_color: Color32` field to `JsonTreeStyle`.
- Captures responses for spaces, commas, colons and collapsed expandables.