### PR TITLE
Rendering refactor, builder pattern, response callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,24 @@ An interactive JSON tree visualisation library for `egui`, with search and highl
 ## Usage
 
 ```rust
-let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
-let tree = JsonTree::new("globally-unique-id", &value);
+use egui::{Color32};
+use egui_json_tree::{DefaultExpand, JsonTreeBuilder, JsonTreeStyle};
 
-// Show the JSON tree:
-let response = tree.show(ui, DefaultExpand::All);
+let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
+
+let response = JsonTreeBuilder::new("globally-unique-id", &value)
+    .style(JsonTreeStyle {
+        bool_color: Color32::YELLOW,
+        ..Default::default()
+    })
+    .default_expand(DefaultExpand::All)
+    .response_callback(|response, json_pointer_str| {
+      // Handle interactions within the JsonTree.
+    })
+    .show(ui);
+
+// Reset the expanded state of all arrays/objects to respect the `default_expand` setting.
+response.reset_expanded(ui);
 ```
 
 See [demo.rs](./examples/demo.rs) and run the examples for more detailed use cases, including the search match highlight/auto expand functionality, and how to copy JSON paths and values to the clipboard.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use eframe::egui::{RichText, Ui};
 use egui::{Align, Button, Layout};
-use egui_json_tree::{DefaultExpand, JsonTree};
+use egui_json_tree::{DefaultExpand, JsonTreeBuilder};
 use serde_json::{json, Value};
 
 trait Show {
@@ -27,7 +27,7 @@ impl Show for Example {
     }
 
     fn show(&mut self, ui: &mut Ui) {
-        JsonTree::new(self.title, &self.value).show(ui);
+        JsonTreeBuilder::new(self.title, &self.value).show(ui);
     }
 }
 
@@ -79,7 +79,7 @@ impl Show for CustomExample {
 
         match value.as_ref() {
             Ok(value) => {
-                JsonTree::new(self.title, value).show(ui);
+                JsonTreeBuilder::new(self.title, value).show(ui);
             }
             Err(err) => {
                 ui.label(RichText::new(err.to_string()).color(ui.visuals().error_fg_color));
@@ -122,7 +122,7 @@ impl Show for SearchExample {
             })
             .inner;
 
-        let response = JsonTree::builder(self.title, &self.value)
+        let response = JsonTreeBuilder::new(self.title, &self.value)
             .default_expand(DefaultExpand::SearchResults(&self.search_input))
             .show(ui);
 
@@ -161,7 +161,7 @@ impl Show for CopyToClipboardExample {
     }
 
     fn show(&mut self, ui: &mut Ui) {
-        JsonTree::builder(self.title, &self.value)
+        JsonTreeBuilder::new(self.title, &self.value)
             .response_callback(|response, pointer| {
                 response.context_menu(|ui| {
                     ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use eframe::egui::{RichText, Ui};
-use egui::{Align, Align2, Area, Button, Frame, Layout, Order, Pos2};
+use egui::{Align, Button, Layout};
 use egui_json_tree::{DefaultExpand, JsonTree};
 use serde_json::{json, Value};
 
@@ -144,7 +144,6 @@ impl Show for SearchExample {
 struct CopyToClipboardExample {
     title: &'static str,
     value: Value,
-    popup_response: Option<(Pos2, String)>,
 }
 
 impl CopyToClipboardExample {
@@ -152,7 +151,6 @@ impl CopyToClipboardExample {
         Self {
             title: "Copy To Clipboard Example",
             value,
-            popup_response: None,
         }
     }
 }
@@ -163,55 +161,35 @@ impl Show for CopyToClipboardExample {
     }
 
     fn show(&mut self, ui: &mut Ui) {
-        let popup_id = ui.make_persistent_id("popup");
+        JsonTree::builder(self.title, &self.value)
+            .response_callback(|response, pointer| {
+                response.context_menu(|ui| {
+                    ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
+                        ui.set_width(150.0);
 
-        let mut should_close_popup = false;
-        if let Some((pos, path)) = &self.popup_response {
-            let area_response = Area::new(popup_id)
-                .order(Order::Foreground)
-                .constrain(true)
-                .fixed_pos(*pos)
-                .pivot(Align2::LEFT_TOP)
-                .show(ui.ctx(), |ui| {
-                    Frame::popup(ui.style()).show(ui, |ui| {
-                        ui.with_layout(Layout::top_down_justified(Align::LEFT), |ui| {
-                            ui.set_width(150.0);
+                        if !pointer.is_empty()
+                            && ui
+                                .add(Button::new("Copy property path").frame(false))
+                                .clicked()
+                        {
+                            println!("{}", pointer);
+                            ui.output_mut(|o| o.copied_text = pointer.clone());
+                            ui.close_menu();
+                        }
 
-                            if !path.is_empty()
-                                && ui
-                                    .add(Button::new("Copy property path").frame(false))
-                                    .clicked()
-                            {
-                                println!("{}", path);
-                                ui.output_mut(|o| o.copied_text = path.clone());
-                                should_close_popup = true;
-                            }
-
-                            if ui.add(Button::new("Copy contents").frame(false)).clicked() {
-                                if let Some(val) = self.value.pointer(path) {
-                                    if let Ok(pretty_str) = serde_json::to_string_pretty(val) {
-                                        println!("{}", pretty_str);
-                                        ui.output_mut(|o| o.copied_text = pretty_str);
-                                    }
+                        if ui.add(Button::new("Copy contents").frame(false)).clicked() {
+                            if let Some(val) = self.value.pointer(&pointer) {
+                                if let Ok(pretty_str) = serde_json::to_string_pretty(val) {
+                                    println!("{}", pretty_str);
+                                    ui.output_mut(|o| o.copied_text = pretty_str);
                                 }
-                                should_close_popup = true;
                             }
-                        });
+                            ui.close_menu();
+                        }
                     });
-                })
-                .response;
-
-            if area_response.clicked_elsewhere() {
-                should_close_popup = true;
-            }
-        }
-
-        if should_close_popup {
-            self.popup_response = None;
-        }
-
-        let tree = JsonTree::new(self.title, &self.value);
-        let response = tree.show(ui);
+                });
+            })
+            .show(ui);
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -27,7 +27,7 @@ impl Show for Example {
     }
 
     fn show(&mut self, ui: &mut Ui) {
-        JsonTree::new(self.title, &self.value).show(ui, DefaultExpand::None);
+        JsonTree::new(self.title, &self.value).show(ui);
     }
 }
 
@@ -79,7 +79,7 @@ impl Show for CustomExample {
 
         match value.as_ref() {
             Ok(value) => {
-                JsonTree::new(self.title, value).show(ui, DefaultExpand::None);
+                JsonTree::new(self.title, value).show(ui);
             }
             Err(err) => {
                 ui.label(RichText::new(err.to_string()).color(ui.visuals().error_fg_color));
@@ -122,8 +122,9 @@ impl Show for SearchExample {
             })
             .inner;
 
-        let tree = JsonTree::new(self.title, &self.value);
-        let response = tree.show(ui, DefaultExpand::SearchResults(&self.search_input));
+        let response = JsonTree::builder(self.title, &self.value)
+            .default_expand(DefaultExpand::SearchResults(&self.search_input))
+            .show(ui);
 
         if text_edit_response.changed() {
             response.reset_expanded(ui);
@@ -210,7 +211,7 @@ impl Show for CopyToClipboardExample {
         }
 
         let tree = JsonTree::new(self.title, &self.value);
-        let response = tree.show(ui, DefaultExpand::None);
+        let response = tree.show(ui);
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -178,7 +178,7 @@ impl Show for CopyToClipboardExample {
                         }
 
                         if ui.add(Button::new("Copy contents").frame(false)).clicked() {
-                            if let Some(val) = self.value.pointer(&pointer) {
+                            if let Some(val) = self.value.pointer(pointer) {
                                 if let Ok(pretty_str) = serde_json::to_string_pretty(val) {
                                     println!("{}", pretty_str);
                                     ui.output_mut(|o| o.copied_text = pretty_str);

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -211,17 +211,6 @@ impl Show for CopyToClipboardExample {
 
         let tree = JsonTree::new(self.title, &self.value);
         let response = tree.show(ui, DefaultExpand::None);
-
-        if let Some((response, path)) = response.inner {
-            if response.secondary_clicked() {
-                self.popup_response = Some((
-                    response
-                        .interact_pointer_pos()
-                        .unwrap_or(response.rect.left_bottom()),
-                    path,
-                ));
-            }
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,25 @@
 //! An interactive JSON tree visualisation library for `egui`, with search and highlight functionality.
 //!
 //! ```
-//! use egui_json_tree::{DefaultExpand, JsonTree};
+//! use egui::{Color32};
+//! use egui_json_tree::{DefaultExpand, JsonTreeBuilder, JsonTreeStyle};
 //!
 //! # egui::__run_test_ui(|ui| {
 //! let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
-//! let tree = JsonTree::new("globally-unique-id", &value);
 //!
-//! // Show the JSON tree:
-//! let response = tree.show(ui, DefaultExpand::All);
+//! let response = JsonTreeBuilder::new("globally-unique-id", &value)
+//!     .style(JsonTreeStyle {
+//!         bool_color: Color32::YELLOW,
+//!         ..Default::default()
+//!     })
+//!     .default_expand(DefaultExpand::All)
+//!     .response_callback(|response, json_pointer_str| {
+//!       // Handle interactions within the JsonTree.
+//!     })
+//!     .show(ui);
+//!
+//! // Reset the expanded state of all arrays/objects to respect the `default_expand` setting.
+//! response.reset_expanded(ui);
 //! # });
 //! ```
 //! [`JsonTree`] can visualise any type that implements [`Into`](std::convert::Into)[`<JsonTreeValue>`](value::JsonTreeValue).
@@ -16,8 +27,7 @@
 //! If you wish to use a different JSON type, see the [`value`](mod@value) module,
 //! and disable default features in your `Cargo.toml` if you do not need the [`serde_json`](serde_json) dependency.
 //!
-//! Coloring for JSON syntax highlighting and search match highlighting may be overriden through the [`JsonTree::style`] builder method.
-
+//! See [`JsonTreeBuilder`] to configure and show a [`JsonTree`].
 mod delimiters;
 mod response;
 mod search;
@@ -28,5 +38,5 @@ mod tree_builder;
 pub use response::JsonTreeResponse;
 pub use style::JsonTreeStyle;
 pub mod value;
-pub use tree::DefaultExpand;
-pub use tree_builder::*;
+pub use tree::{DefaultExpand, JsonTree};
+pub use tree_builder::JsonTreeBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,6 @@ mod tree_builder;
 
 pub use response::JsonTreeResponse;
 pub use style::JsonTreeStyle;
-pub use tree::*;
 pub mod value;
+pub use tree::DefaultExpand;
+pub use tree_builder::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod response;
 mod search;
 mod style;
 mod tree;
+mod tree_builder;
 
 pub use response::JsonTreeResponse;
 pub use style::JsonTreeStyle;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,16 +1,9 @@
 use std::collections::HashSet;
 
-use egui::{collapsing_header::CollapsingState, Id, Response, Ui};
+use egui::{collapsing_header::CollapsingState, Id, Ui};
 
 /// The response from showing a [`JsonTree`](crate::JsonTree).
 pub struct JsonTreeResponse {
-    /// If any object key, array index, or value was hovered, this `Option` will contain the [`Response`](egui::Response)
-    /// and JSON pointer string.
-    ///
-    /// The JSON pointer is an identifier composed of each subsequent object key or array index, e.g. `"/foo/bar/0"`.
-    ///
-    /// For anything hovered within a collapsed top-level array/object, the JSON pointer string will refer to the entire JSON document, i.e. `""`.
-    pub inner: Option<(Response, String)>,
     pub(crate) collapsing_state_ids: HashSet<Id>,
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -9,9 +9,10 @@ pub struct JsonTreeResponse {
 
 impl JsonTreeResponse {
     /// For the [`JsonTree`](crate::JsonTree) that provided this response,
-    /// resets the expanded state for all of its arrays/objects to respect the `default_expand` argument of [`JsonTree::show`](crate::JsonTree::show) on the next render.
+    /// resets the expanded state for all of its arrays/objects to respect the `default_expand` setting.
     ///
-    /// Call this whenever the `default_expand` argument changes, and/or you when wish to reset any manually collapsed/expanded arrays and objects to respect this argument.
+    /// Call this whenever the `default_expand` setting changes,
+    /// and/or you when wish to reset any manually collapsed/expanded arrays and objects to respect this setting.
     pub fn reset_expanded(&self, ui: &mut Ui) {
         for id in self.collapsing_state_ids.iter() {
             if let Some(state) = CollapsingState::load(ui.ctx(), *id) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -15,7 +15,7 @@ use crate::{
     response::JsonTreeResponse,
     search::SearchTerm,
     style::JsonTreeStyle,
-    tree_builder::{JsonTreeBuilder, JsonTreeConfig},
+    tree_builder::JsonTreeConfig,
     value::{BaseValueType, ExpandableType, JsonTreeValue},
 };
 
@@ -46,28 +46,13 @@ pub struct JsonTree {
     parent: Option<Parent>,
 }
 
-impl<'a> JsonTree {
-    /// Creates a new [`JsonTree`].
-    /// `id` must be a globally unique identifier.
-    pub fn new(id: impl Hash, value: impl Into<JsonTreeValue>) -> Self {
+impl JsonTree {
+    pub(crate) fn new(id: impl Hash, value: impl Into<JsonTreeValue>) -> Self {
         Self {
             id: Id::new(id),
             value: value.into(),
             parent: None,
         }
-    }
-
-    pub fn builder(id: impl Hash, value: impl Into<JsonTreeValue>) -> JsonTreeBuilder<'a> {
-        JsonTreeBuilder {
-            id: Id::new(id),
-            value: value.into(),
-            config: JsonTreeConfig::default(),
-        }
-    }
-
-    /// Show the JSON tree visualisation within the `Ui`.
-    pub fn show(self, ui: &mut Ui) -> JsonTreeResponse {
-        self.show_with_config(ui, JsonTreeConfig::default())
     }
 
     pub(crate) fn show_with_config(self, ui: &mut Ui, config: JsonTreeConfig) -> JsonTreeResponse {
@@ -145,8 +130,7 @@ impl<'a> JsonTree {
                 ui.horizontal_wrapped(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
                     show_job(ui, job)
-                })
-                .inner;
+                });
             }
             JsonTreeValue::Expandable(entries, expandable_type) => {
                 let expandable = Expandable {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    hash::Hash,
-};
+use std::collections::{HashMap, HashSet};
 
 use egui::{
     collapsing_header::CollapsingState,
@@ -47,10 +44,10 @@ pub struct JsonTree {
 }
 
 impl JsonTree {
-    pub(crate) fn new(id: impl Hash, value: impl Into<JsonTreeValue>) -> Self {
+    pub(crate) fn new(id: Id, value: JsonTreeValue) -> Self {
         Self {
-            id: Id::new(id),
-            value: value.into(),
+            id,
+            value,
             parent: None,
         }
     }
@@ -471,7 +468,7 @@ struct Expandable {
     parent: Option<Parent>,
 }
 
-pub(crate) struct Parent {
+pub struct Parent {
     key: String,
     expandable_type: ExpandableType,
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -135,7 +135,11 @@ impl<'a> JsonTree {
         match self.value {
             JsonTreeValue::Base(value_str, value_type) => {
                 let mut job = LayoutJob::default();
-                add_key(&mut job, style, &self.parent, search_term);
+
+                if let Some(parent) = &self.parent {
+                    add_key(&mut job, style, parent, search_term);
+                }
+
                 add_value(&mut job, style, &value_str, &value_type, search_term);
 
                 ui.horizontal_wrapped(|ui| {
@@ -232,7 +236,7 @@ fn show_expandable(
                             add_key(
                                 &mut job,
                                 style,
-                                &Some(Parent::new(key.to_owned(), expandable.expandable_type)),
+                                &Parent::new(key.to_owned(), expandable.expandable_type),
                                 search_term,
                             );
                         }
@@ -265,7 +269,9 @@ fn show_expandable(
                 } else {
                     let mut job = LayoutJob::default();
 
-                    add_key(&mut job, style, &expandable.parent, search_term);
+                    if let Some(parent) = &expandable.parent {
+                        add_key(&mut job, style, parent, search_term);
+                    }
 
                     if is_expanded {
                         append(&mut job, delimiters.opening, style.punctuation_color, None);
@@ -339,18 +345,18 @@ fn show_expandable(
 fn add_key(
     job: &mut LayoutJob,
     style: &JsonTreeStyle,
-    parent: &Option<Parent>,
+    parent: &Parent,
     search_term: &Option<SearchTerm>,
 ) {
     match parent {
-        Some(Parent {
+        Parent {
             key,
             expandable_type: ExpandableType::Array,
-        }) => add_array_idx(job, key, style.array_idx_color, style.punctuation_color),
-        Some(Parent {
+        } => add_array_idx(job, key, style.array_idx_color, style.punctuation_color),
+        Parent {
             key,
             expandable_type: ExpandableType::Object,
-        }) => add_object_key(
+        } => add_object_key(
             job,
             key,
             style.object_key_color,
@@ -358,7 +364,6 @@ fn add_key(
             search_term,
             style.highlight_color,
         ),
-        _ => {}
     };
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -107,6 +107,7 @@ impl JsonTree {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn show_impl(
         self,
         ui: &mut Ui,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -17,26 +17,6 @@ use crate::{
 };
 
 /// An interactive JSON tree visualiser.
-///
-/// ```
-/// use egui_json_tree::{DefaultExpand, JsonTree, JsonTreeStyle};
-///
-/// # egui::__run_test_ui(|ui| {
-/// let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
-/// let tree = JsonTree::new("globally-unique-id", &value).style(JsonTreeStyle {
-///     null_color: egui::Color32::RED,
-///     ..Default::default()
-/// });
-///
-/// // Show the JSON tree:
-/// let response = tree.show(ui, DefaultExpand::All);
-///
-/// // Reset which arrays and objects are expanded to respect the `default_expand` argument on the next render.
-/// // In this case, this will expand all arrays and objects again,
-/// // if a user had collapsed any manually.
-/// response.reset_expanded(ui);
-/// # });
-/// ```
 pub struct JsonTree {
     id: Id,
     value: JsonTreeValue,
@@ -433,7 +413,7 @@ fn render_job(ui: &mut Ui, job: LayoutJob) -> Response {
 }
 
 #[derive(Default, Debug, Clone)]
-/// Configuration for how a `JsonTree` should expand arrays and objects by default.
+/// Configuration for how a [`JsonTree`] should expand arrays and objects by default.
 pub enum DefaultExpand<'a> {
     /// Expand all arrays and objects.
     All,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -99,6 +99,10 @@ impl<'a> JsonTree {
             }
         };
 
+        let response_callback = &mut config
+            .response_callback
+            .unwrap_or_else(|| Box::new(|_, _| {}));
+
         // Wrap in a vertical layout in case this tree is placed directly in a horizontal layout,
         // which does not allow indent layouts as direct children.
         ui.vertical(|ui| {
@@ -109,6 +113,7 @@ impl<'a> JsonTree {
                 &config.style,
                 &default_expand,
                 &search_term,
+                response_callback,
             );
         });
 
@@ -125,6 +130,7 @@ impl<'a> JsonTree {
         style: &JsonTreeStyle,
         default_expand: &InnerExpand,
         search_term: &Option<SearchTerm>,
+        response_callback: &mut dyn FnMut(Response, String),
     ) {
         match self.value {
             JsonTreeValue::Base(value_str, value_type) => {
@@ -153,6 +159,7 @@ impl<'a> JsonTree {
                     style,
                     default_expand,
                     search_term,
+                    response_callback,
                 );
             }
         };
@@ -184,6 +191,7 @@ fn show_expandable(
     style: &JsonTreeStyle,
     default_expand: &InnerExpand,
     search_term: &Option<SearchTerm>,
+    response_callback: &mut dyn FnMut(Response, String),
 ) {
     let delimiters = match expandable.expandable_type {
         ExpandableType::Array => &ARRAY_DELIMITERS,
@@ -293,6 +301,7 @@ fn show_expandable(
                         style,
                         default_expand,
                         search_term,
+                        response_callback,
                     );
                 };
 

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 pub struct JsonTreeConfig<'a> {
     pub(crate) style: JsonTreeStyle,
     pub(crate) default_expand: DefaultExpand<'a>,
-    pub(crate) response_callback: Option<Box<dyn FnMut(Response, String) + 'a>>,
+    pub(crate) response_callback: Option<Box<dyn FnMut(Response, &String) + 'a>>,
 }
 
 #[must_use = "You should call .show()"]
@@ -44,7 +44,7 @@ impl<'a> JsonTreeBuilder<'a> {
 
     pub fn response_callback(
         mut self,
-        response_callback: impl FnMut(Response, String) + 'a,
+        response_callback: impl FnMut(Response, &String) + 'a,
     ) -> Self {
         self.config.response_callback = Some(Box::new(response_callback));
         self

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,0 +1,31 @@
+use egui::{Id, Ui};
+
+use crate::{value::JsonTreeValue, DefaultExpand, JsonTree, JsonTreeResponse, JsonTreeStyle};
+
+#[derive(Default)]
+pub struct JsonTreeConfig<'a> {
+    pub(crate) style: JsonTreeStyle,
+    pub(crate) default_expand: DefaultExpand<'a>,
+}
+
+pub struct JsonTreeBuilder<'a> {
+    pub(crate) id: Id,
+    pub(crate) value: JsonTreeValue,
+    pub(crate) config: JsonTreeConfig<'a>,
+}
+
+impl<'a> JsonTreeBuilder<'a> {
+    pub fn style(mut self, style: JsonTreeStyle) -> Self {
+        self.config.style = style;
+        self
+    }
+
+    pub fn default_expand(mut self, default_expand: DefaultExpand<'a>) -> Self {
+        self.config.default_expand = default_expand;
+        self
+    }
+
+    pub fn show(self, ui: &mut Ui) -> JsonTreeResponse {
+        JsonTree::new(self.id, self.value).show_with_config(ui, self.config)
+    }
+}

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -15,6 +15,7 @@ pub struct JsonTreeConfig<'a> {
     pub(crate) response_callback: Option<Box<ResponseCallback<'a>>>,
 }
 
+/// Builder for a [`JsonTree`]. Use this to configure and show a [`JsonTree`].
 #[must_use = "You should call .show()"]
 pub struct JsonTreeBuilder<'a> {
     id: Id,
@@ -39,11 +40,15 @@ impl<'a> JsonTreeBuilder<'a> {
         self
     }
 
+    /// Override how the [`JsonTree`] expands arrays/objects by default.
     pub fn default_expand(mut self, default_expand: DefaultExpand<'a>) -> Self {
         self.config.default_expand = default_expand;
         self
     }
 
+    /// Register a callback to handle interactions within a [`JsonTree`].
+    /// - `Response`: The `Response` from rendering an array index, object key or value.
+    /// - `&String`: A JSON pointer string.
     pub fn response_callback(
         mut self,
         response_callback: impl FnMut(Response, &String) + 'a,

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -17,9 +17,9 @@ pub struct JsonTreeConfig<'a> {
 
 #[must_use = "You should call .show()"]
 pub struct JsonTreeBuilder<'a> {
-    pub(crate) id: Id,
-    pub(crate) value: JsonTreeValue,
-    pub(crate) config: JsonTreeConfig<'a>,
+    id: Id,
+    value: JsonTreeValue,
+    config: JsonTreeConfig<'a>,
 }
 
 impl<'a> JsonTreeBuilder<'a> {

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -6,11 +6,13 @@ use crate::{
 use egui::{Id, Response, Ui};
 use std::hash::Hash;
 
+type ResponseCallback<'a> = dyn FnMut(Response, &String) + 'a;
+
 #[derive(Default)]
 pub struct JsonTreeConfig<'a> {
     pub(crate) style: JsonTreeStyle,
     pub(crate) default_expand: DefaultExpand<'a>,
-    pub(crate) response_callback: Option<Box<dyn FnMut(Response, &String) + 'a>>,
+    pub(crate) response_callback: Option<Box<ResponseCallback<'a>>>,
 }
 
 #[must_use = "You should call .show()"]

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,4 +1,4 @@
-use egui::{Id, Ui};
+use egui::{Id, Response, Ui};
 
 use crate::{value::JsonTreeValue, DefaultExpand, JsonTree, JsonTreeResponse, JsonTreeStyle};
 
@@ -6,6 +6,7 @@ use crate::{value::JsonTreeValue, DefaultExpand, JsonTree, JsonTreeResponse, Jso
 pub struct JsonTreeConfig<'a> {
     pub(crate) style: JsonTreeStyle,
     pub(crate) default_expand: DefaultExpand<'a>,
+    pub(crate) response_callback: Option<Box<dyn FnMut(Response, String) + 'a>>,
 }
 
 pub struct JsonTreeBuilder<'a> {
@@ -22,6 +23,14 @@ impl<'a> JsonTreeBuilder<'a> {
 
     pub fn default_expand(mut self, default_expand: DefaultExpand<'a>) -> Self {
         self.config.default_expand = default_expand;
+        self
+    }
+
+    pub fn response_callback(
+        mut self,
+        response_callback: impl FnMut(Response, String) + 'a,
+    ) -> Self {
+        self.config.response_callback = Some(Box::new(response_callback));
         self
     }
 

--- a/src/tree_builder.rs
+++ b/src/tree_builder.rs
@@ -1,6 +1,10 @@
+use crate::{
+    tree::{DefaultExpand, JsonTree},
+    value::JsonTreeValue,
+    JsonTreeResponse, JsonTreeStyle,
+};
 use egui::{Id, Response, Ui};
-
-use crate::{value::JsonTreeValue, DefaultExpand, JsonTree, JsonTreeResponse, JsonTreeStyle};
+use std::hash::Hash;
 
 #[derive(Default)]
 pub struct JsonTreeConfig<'a> {
@@ -9,6 +13,7 @@ pub struct JsonTreeConfig<'a> {
     pub(crate) response_callback: Option<Box<dyn FnMut(Response, String) + 'a>>,
 }
 
+#[must_use = "You should call .show()"]
 pub struct JsonTreeBuilder<'a> {
     pub(crate) id: Id,
     pub(crate) value: JsonTreeValue,
@@ -16,6 +21,17 @@ pub struct JsonTreeBuilder<'a> {
 }
 
 impl<'a> JsonTreeBuilder<'a> {
+    /// Creates a new [`JsonTreeBuilder`].
+    /// `id` must be a globally unique identifier.
+    pub fn new(id: impl Hash, value: impl Into<JsonTreeValue>) -> Self {
+        Self {
+            id: Id::new(id),
+            value: value.into(),
+            config: JsonTreeConfig::default(),
+        }
+    }
+
+    /// Override colors for JSON syntax highlighting, and search match highlighting.
     pub fn style(mut self, style: JsonTreeStyle) -> Self {
         self.config.style = style;
         self
@@ -34,6 +50,7 @@ impl<'a> JsonTreeBuilder<'a> {
         self
     }
 
+    /// Show the JSON tree visualisation within the `Ui`.
     pub fn show(self, ui: &mut Ui) -> JsonTreeResponse {
         JsonTree::new(self.id, self.value).show_with_config(ui, self.config)
     }


### PR DESCRIPTION
- Refactor to use `LayoutJob` instead of `Vec<RichText>` for rendering.
- Introduces `JsonTreeBuilder` for constructing and showing a `JsonTree`.
- Adds response callback to handle interactions within the `JsonTree`.