### PR TITLE
Use monospace font ID defined by app by default

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -69,7 +69,7 @@ impl JsonTreeNode {
         // which does not allow indent layouts as direct children.
         ui.vertical(|ui| {
             // Centres the collapsing header icon.
-            ui.spacing_mut().interact_size.y = config.style.font_id.size;
+            ui.spacing_mut().interact_size.y = config.style.font_id(ui).size;
 
             self.show_impl(
                 ui,
@@ -150,7 +150,7 @@ fn render_value(
         style.get_color(value_type),
         search_term,
         style.highlight_color,
-        &style.font_id,
+        &style.font_id(ui),
     );
     render_job(ui, job)
 }
@@ -187,6 +187,8 @@ fn show_expandable(
     let state = CollapsingState::load_with_default_open(ui.ctx(), id_source, default_open);
     let is_expanded = state.is_open();
 
+    let font_id = style.font_id(ui);
+
     state
         .show_header(ui, |ui| {
             ui.horizontal_wrapped(|ui| {
@@ -198,9 +200,9 @@ fn show_expandable(
                         delimiters.opening,
                         style.punctuation_color,
                         None,
-                        &style.font_id,
+                        &font_id,
                     );
-                    render_punc(ui, " ", style.punctuation_color, None, &style.font_id);
+                    render_punc(ui, " ", style.punctuation_color, None, &font_id);
 
                     let entries_len = expandable.entries.len();
 
@@ -233,19 +235,13 @@ fn show_expandable(
                                     nested_delimiters.collapsed,
                                     style.punctuation_color,
                                     None,
-                                    &style.font_id,
+                                    &font_id,
                                 );
                                 response_callback(collapsed_expandable_response, pointer_string);
                             }
                         };
                         let spacing_str = if idx == entries_len - 1 { " " } else { ", " };
-                        render_punc(
-                            ui,
-                            spacing_str,
-                            style.punctuation_color,
-                            None,
-                            &style.font_id,
-                        );
+                        render_punc(ui, spacing_str, style.punctuation_color, None, &font_id);
                     }
 
                     render_punc(
@@ -253,7 +249,7 @@ fn show_expandable(
                         delimiters.closing,
                         style.punctuation_color,
                         None,
-                        &style.font_id,
+                        &font_id,
                     );
                 } else {
                     if let Some(parent) = &expandable.parent {
@@ -267,7 +263,7 @@ fn show_expandable(
                             delimiters.opening,
                             style.punctuation_color,
                             None,
-                            &style.font_id,
+                            &font_id,
                         );
                     } else {
                         let collapsed_expandable_response = render_punc(
@@ -275,7 +271,7 @@ fn show_expandable(
                             delimiters.collapsed,
                             style.punctuation_color,
                             None,
-                            &style.font_id,
+                            &font_id,
                         );
                         response_callback(collapsed_expandable_response, pointer_string);
                     }
@@ -334,7 +330,7 @@ fn show_expandable(
                 delimiters.closing,
                 style.punctuation_color,
                 None,
-                &style.font_id,
+                &font_id,
             );
         });
     }
@@ -356,7 +352,7 @@ fn render_key(
             key,
             style.array_idx_color,
             style.punctuation_color,
-            &style.font_id,
+            &style.font_id(ui),
         ),
         Parent {
             key,
@@ -368,7 +364,7 @@ fn render_key(
             style.punctuation_color,
             search_term,
             style.highlight_color,
-            &style.font_id,
+            &style.font_id(ui),
         ),
     };
     render_job(ui, job)

--- a/src/style.rs
+++ b/src/style.rs
@@ -14,7 +14,7 @@ pub struct JsonTreeStyle {
     pub highlight_color: Color32,
     /// The text color for array brackets, object braces, colons and commas.
     pub punctuation_color: Color32,
-    /// The font to use. Defaults to TextStyle::Monospace.resolve(ui.style())
+    /// The font to use. Defaults to `TextStyle::Monospace.resolve(ui.style())`.
     pub font_id: Option<FontId>,
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, FontId};
+use egui::{Color32, FontId, TextStyle, Ui};
 
 use crate::value::BaseValueType;
 
@@ -14,7 +14,8 @@ pub struct JsonTreeStyle {
     pub highlight_color: Color32,
     /// The text color for array brackets, object braces, colons and commas.
     pub punctuation_color: Color32,
-    pub font_id: FontId,
+    /// The font to use. Defaults to TextStyle::Monospace.resolve(ui.style())
+    pub font_id: Option<FontId>,
 }
 
 impl Default for JsonTreeStyle {
@@ -28,7 +29,7 @@ impl Default for JsonTreeStyle {
             string_color: Color32::from_rgb(194, 146, 122),
             highlight_color: Color32::from_rgba_premultiplied(72, 72, 72, 50),
             punctuation_color: Color32::from_gray(140),
-            font_id: FontId::monospace(12.0),
+            font_id: None,
         }
     }
 }
@@ -40,6 +41,14 @@ impl JsonTreeStyle {
             BaseValueType::Bool => self.bool_color,
             BaseValueType::Number => self.number_color,
             BaseValueType::String => self.string_color,
+        }
+    }
+
+    pub(crate) fn font_id(&self, ui: &Ui) -> FontId {
+        if let Some(font_id) = &self.font_id {
+            font_id.clone()
+        } else {
+            TextStyle::Monospace.resolve(ui.style())
         }
     }
 }


### PR DESCRIPTION
Instead of defaulting to 12pt, use whatever the application has previously defined.

In my particular case, I changed the default font size to 11pt so this makes it so users don't have to set the font_id for every `JsonTree` just to match the rest of their app.