### PR TITLE
Use empty delimiters for empty arrays/objects

### DIFF
--- a/src/delimiters.rs
+++ b/src/delimiters.rs
@@ -1,17 +1,20 @@
 pub struct Delimiters {
     pub collapsed: &'static str,
+    pub collapsed_empty: &'static str,
     pub opening: &'static str,
     pub closing: &'static str,
 }
 
 pub const ARRAY_DELIMITERS: Delimiters = Delimiters {
     collapsed: "[...]",
+    collapsed_empty: "[]",
     opening: "[",
     closing: "]",
 };
 
 pub const OBJECT_DELIMITERS: Delimiters = Delimiters {
     collapsed: "{...}",
+    collapsed_empty: "{}",
     opening: "{",
     closing: "}",
 };

--- a/src/node.rs
+++ b/src/node.rs
@@ -224,15 +224,21 @@ fn show_expandable(
                                     render_value(ui, style, value_str, value_type, search_term);
                                 response_callback(value_response, pointer_string);
                             }
-                            JsonTreeValue::Expandable(_, expandable_type) => {
+                            JsonTreeValue::Expandable(values, expandable_type) => {
                                 let nested_delimiters = match expandable_type {
                                     ExpandableType::Array => &ARRAY_DELIMITERS,
                                     ExpandableType::Object => &OBJECT_DELIMITERS,
                                 };
 
+                                let delimiter = if values.is_empty() {
+                                    nested_delimiters.collapsed_empty
+                                } else {
+                                    nested_delimiters.collapsed
+                                };
+
                                 let collapsed_expandable_response = render_punc(
                                     ui,
-                                    nested_delimiters.collapsed,
+                                    delimiter,
                                     style.punctuation_color,
                                     None,
                                     &font_id,
@@ -266,13 +272,13 @@ fn show_expandable(
                             &font_id,
                         );
                     } else {
-                        let collapsed_expandable_response = render_punc(
-                            ui,
-                            delimiters.collapsed,
-                            style.punctuation_color,
-                            None,
-                            &font_id,
-                        );
+                        let delimiter = if expandable.entries.is_empty() {
+                            delimiters.collapsed_empty
+                        } else {
+                            delimiters.collapsed
+                        };
+                        let collapsed_expandable_response =
+                            render_punc(ui, delimiter, style.punctuation_color, None, &font_id);
                         response_callback(collapsed_expandable_response, pointer_string);
                     }
                 }


### PR DESCRIPTION
Display empty array/object when their are empty


https://github.com/dmackdev/egui_json_tree/assets/1410520/d7f8601b-3187-4af1-ba60-1d6dc4e4a61f

Closes https://github.com/dmackdev/egui_json_tree/issues/5.