### PR TITLE
Lazy JSON conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ response.reset_expanded(ui);
 
 See [demo.rs](./examples/demo.rs) and run the examples for more detailed use cases, including the search match highlight/auto expand functionality, and how to copy JSON paths and values to the clipboard.
 
-`JsonTree` can visualise any type that implements `Into<JsonTreeValue>`. An implementation to support `serde_json::Value` is provided with this crate. If you wish to use a different JSON type, see the `value` module, and disable default features in your `Cargo.toml` if you do not need the `serde_json` dependency.
+`JsonTree` can visualise any type that implements `value::ToJsonTreeValue`. An implementation to support `serde_json::Value` is provided with this crate. If you wish to use a different JSON type, see the `value` module, and disable default features in your `Cargo.toml` if you do not need the `serde_json` dependency.
 
 ## Run Examples
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -61,7 +61,7 @@ impl Show for CustomExample {
                 .desired_width(f32::INFINITY),
         );
 
-        let value = serde_json::from_str(&self.input);
+        let value: serde_json::Result<Value> = serde_json::from_str(&self.input);
         let pretty_string = value
             .as_ref()
             .ok()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! response.reset_expanded(ui);
 //! # });
 //! ```
-//! [`JsonTree`] can visualise any type that implements [`Into`](std::convert::Into)[`<JsonTreeValue>`](value::JsonTreeValue).
+//! [`JsonTree`] can visualise any type that implements [`ToJsonTreeValue`](trait@value::ToJsonTreeValue).
 //! An implementation to support [`serde_json::Value`](serde_json::Value) is provided with this crate.
 //! If you wish to use a different JSON type, see the [`value`](mod@value) module,
 //! and disable default features in your `Cargo.toml` if you do not need the [`serde_json`](serde_json) dependency.

--- a/src/node.rs
+++ b/src/node.rs
@@ -107,7 +107,7 @@ impl<'a> JsonTreeNode<'a> {
                     }
 
                     let value_response =
-                        render_value(ui, style, &value_str, &value_type, search_term);
+                        render_value(ui, style, &value_str.to_string(), &value_type, search_term);
                     response_callback(value_response, pointer_string);
                 });
             }
@@ -141,15 +141,24 @@ fn render_value(
     value_type: &BaseValueType,
     search_term: Option<&SearchTerm>,
 ) -> Response {
+    let color = style.get_color(value_type);
+    let font_id = &style.font_id(ui);
+    let add_quote_if_string = |job: &mut LayoutJob| {
+        if *value_type == BaseValueType::String {
+            append(job, "\"", color, None, font_id)
+        };
+    };
     let mut job = LayoutJob::default();
+    add_quote_if_string(&mut job);
     add_text_with_highlighting(
         &mut job,
         value_str,
-        style.get_color(value_type),
+        color,
         search_term,
         style.highlight_color,
-        &style.font_id(ui),
+        font_id,
     );
+    add_quote_if_string(&mut job);
     render_job(ui, job)
 }
 
@@ -219,8 +228,13 @@ fn show_expandable(
 
                         match elem.to_json_tree_value() {
                             JsonTreeValue::Base(value_str, value_type) => {
-                                let value_response =
-                                    render_value(ui, style, &value_str, &value_type, search_term);
+                                let value_response = render_value(
+                                    ui,
+                                    style,
+                                    &value_str.to_string(),
+                                    &value_type,
+                                    search_term,
+                                );
                                 response_callback(value_response, pointer_string);
                             }
                             JsonTreeValue::Expandable(entries, expandable_type) => {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::value::{ExpandableType, IntoJsonTreeValue, JsonTreeValue};
+use crate::value::{ExpandableType, JsonTreeValue, ToJsonTreeValue};
 
 #[derive(Debug, Clone, Hash)]
 pub struct SearchTerm(String);
@@ -26,7 +26,7 @@ impl SearchTerm {
         self.0.len()
     }
 
-    pub fn find_matching_paths_in(&self, value: &dyn IntoJsonTreeValue) -> HashSet<Vec<String>> {
+    pub fn find_matching_paths_in(&self, value: &dyn ToJsonTreeValue) -> HashSet<Vec<String>> {
         let mut matching_paths = HashSet::new();
 
         search_impl(value, self, &mut vec![], &mut matching_paths);
@@ -45,12 +45,12 @@ impl SearchTerm {
 }
 
 fn search_impl(
-    value: &dyn IntoJsonTreeValue,
+    value: &dyn ToJsonTreeValue,
     search_term: &SearchTerm,
     path_segments: &mut Vec<String>,
     matching_paths: &mut HashSet<Vec<String>>,
 ) {
-    match value.into_json_tree_value() {
+    match value.to_json_tree_value() {
         JsonTreeValue::Base(value_str, _) => {
             if search_term.matches(&value_str) {
                 update_matches(path_segments, matching_paths);

--- a/src/search.rs
+++ b/src/search.rs
@@ -52,7 +52,7 @@ fn search_impl(
 ) {
     match value.to_json_tree_value() {
         JsonTreeValue::Base(value_str, _) => {
-            if search_term.matches(&value_str) {
+            if search_term.matches(value_str) {
                 update_matches(path_segments, matching_paths);
             }
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,5 @@
 use crate::{
-    node::JsonTreeNode, value::IntoJsonTreeValue, DefaultExpand, JsonTreeResponse, JsonTreeStyle,
+    node::JsonTreeNode, value::ToJsonTreeValue, DefaultExpand, JsonTreeResponse, JsonTreeStyle,
 };
 use egui::{Id, Response, Ui};
 use std::hash::Hash;
@@ -17,14 +17,14 @@ pub struct JsonTreeConfig<'a> {
 #[must_use = "You should call .show()"]
 pub struct JsonTree<'a> {
     id: Id,
-    value: &'a dyn IntoJsonTreeValue,
+    value: &'a dyn ToJsonTreeValue,
     config: JsonTreeConfig<'a>,
 }
 
 impl<'a> JsonTree<'a> {
     /// Creates a new [`JsonTree`].
     /// `id` must be a globally unique identifier.
-    pub fn new(id: impl Hash, value: &'a impl IntoJsonTreeValue) -> Self {
+    pub fn new(id: impl Hash, value: &'a impl ToJsonTreeValue) -> Self {
         Self {
             id: Id::new(id),
             value,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,5 @@
 use crate::{
-    node::JsonTreeNode, value::JsonTreeValue, DefaultExpand, JsonTreeResponse, JsonTreeStyle,
+    node::JsonTreeNode, value::IntoJsonTreeValue, DefaultExpand, JsonTreeResponse, JsonTreeStyle,
 };
 use egui::{Id, Response, Ui};
 use std::hash::Hash;
@@ -17,17 +17,17 @@ pub struct JsonTreeConfig<'a> {
 #[must_use = "You should call .show()"]
 pub struct JsonTree<'a> {
     id: Id,
-    value: JsonTreeValue,
+    value: &'a dyn IntoJsonTreeValue,
     config: JsonTreeConfig<'a>,
 }
 
 impl<'a> JsonTree<'a> {
     /// Creates a new [`JsonTree`].
     /// `id` must be a globally unique identifier.
-    pub fn new(id: impl Hash, value: impl Into<JsonTreeValue>) -> Self {
+    pub fn new(id: impl Hash, value: &'a impl IntoJsonTreeValue) -> Self {
         Self {
             id: Id::new(id),
-            value: value.into(),
+            value,
             config: JsonTreeConfig::default(),
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,11 +1,10 @@
 //! Representation of JSON values for presentation purposes.
 //!
-//! Write your own [`From`] or [`Into`] implementation which converts to [`JsonTreeValue`] if you wish to visualise a custom JSON type with a [`JsonTree`](crate::JsonTree),
+//! Write your own [`ToJsonTreeValue`] implementation which converts to [`JsonTreeValue`] if you wish to visualise a custom JSON type with a [`JsonTree`](crate::JsonTree),
 //! and disable default features in your `Cargo.toml` if you do not need the [`serde_json`](serde_json) dependency.
 //!
-//! See the [`From<&serde_json::Value> for JsonTreeValue`](../../src/egui_json_tree/value.rs.html#39-65) implementation for reference.
+//! See the [`impl ToJsonTreeValue for serde_json::Value `](../../src/egui_json_tree/value.rs.html#43-77) implementation for reference.
 /// Representation of JSON values for presentation purposes.
-// #[derive(Debug, Clone, Hash)]
 pub enum JsonTreeValue<'a> {
     /// Representation for a non-recursive JSON value:
     /// - A `String` representation of the base value, e.g. `"true"` for the boolean value `true`. The representation for a JSON `String` should be quoted.

--- a/src/value.rs
+++ b/src/value.rs
@@ -16,7 +16,7 @@ pub enum JsonTreeValue<'a> {
     ///   - For arrays, the key should be the index of each element.
     ///   - For objects, the key should be the key of each object entry, without quotes.
     /// - The type of the recursive value, i.e. array or object.
-    Expandable(Vec<(String, &'a dyn IntoJsonTreeValue)>, ExpandableType),
+    Expandable(Vec<(String, &'a dyn ToJsonTreeValue)>, ExpandableType),
 }
 
 /// The type of a non-recursive JSON value.
@@ -35,14 +35,14 @@ pub enum ExpandableType {
     Object,
 }
 
-pub trait IntoJsonTreeValue {
-    fn into_json_tree_value(&self) -> JsonTreeValue;
+pub trait ToJsonTreeValue {
+    fn to_json_tree_value(&self) -> JsonTreeValue;
     fn is_expandable(&self) -> bool;
 }
 
 #[cfg(feature = "serde_json")]
-impl IntoJsonTreeValue for serde_json::Value {
-    fn into_json_tree_value(&self) -> JsonTreeValue {
+impl ToJsonTreeValue for serde_json::Value {
+    fn to_json_tree_value(&self) -> JsonTreeValue {
         match self {
             serde_json::Value::Null => JsonTreeValue::Base("null".to_string(), BaseValueType::Null),
             serde_json::Value::Bool(b) => JsonTreeValue::Base(b.to_string(), BaseValueType::Bool),
@@ -55,13 +55,13 @@ impl IntoJsonTreeValue for serde_json::Value {
             serde_json::Value::Array(arr) => JsonTreeValue::Expandable(
                 arr.iter()
                     .enumerate()
-                    .map(|(idx, elem)| (idx.to_string(), elem as &dyn IntoJsonTreeValue))
+                    .map(|(idx, elem)| (idx.to_string(), elem as &dyn ToJsonTreeValue))
                     .collect(),
                 ExpandableType::Array,
             ),
             serde_json::Value::Object(obj) => JsonTreeValue::Expandable(
                 obj.iter()
-                    .map(|(key, val)| (key.to_owned(), val as &dyn IntoJsonTreeValue))
+                    .map(|(key, val)| (key.to_owned(), val as &dyn ToJsonTreeValue))
                     .collect(),
                 ExpandableType::Object,
             ),


### PR DESCRIPTION
Before, the whole JSON would be traversed and converted to `JsonTreeValue` up front. This PR introduces lazy conversion to only convert the current JSON value that needs to be rendered. A reference to the trait object `ToJsonTreeValue` is now stored in the `JsonTree`, and the conversion to `JsonTreeValue` is performed as needed.

If not using `DefaultExpand::SearchResults(_)`, the `path_id_map` can also be populated lazily, since only those arrays/objects that were rendered could possibly need a reset for their expanded state.

If using `DefaultExpand::SearchResults(_)`, the entire `path_id_map` needs to be populated and the entire JSON needs to be traversed and converted up front, since a child array/object might need to be expanded, so this cannot be done lazily.

This PR also ensures consistency of persistent IDs by using a single callback, which generates an ID based on the top-level UI ID, the tree ID and the path segments.