### PR TITLE
Add `abbreviate_root` setting

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -26,12 +26,16 @@ impl SearchTerm {
         self.0.len()
     }
 
-    pub fn find_matching_paths_in(&self, value: &dyn ToJsonTreeValue) -> HashSet<Vec<String>> {
+    pub fn find_matching_paths_in(
+        &self,
+        value: &dyn ToJsonTreeValue,
+        abbreviate_root: bool,
+    ) -> HashSet<Vec<String>> {
         let mut matching_paths = HashSet::new();
 
         search_impl(value, self, &mut vec![], &mut matching_paths);
 
-        if matching_paths.len() == 1 {
+        if !abbreviate_root && matching_paths.len() == 1 {
             // The only match was a top level key or value - no need to expand anything.
             matching_paths.clear();
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -11,6 +11,7 @@ pub struct JsonTreeConfig<'a> {
     pub(crate) style: JsonTreeStyle,
     pub(crate) default_expand: DefaultExpand<'a>,
     pub(crate) response_callback: Option<Box<ResponseCallback<'a>>>,
+    pub(crate) abbreviate_root: bool,
 }
 
 /// An interactive JSON tree visualiser.
@@ -52,6 +53,16 @@ impl<'a> JsonTree<'a> {
         response_callback: impl FnMut(Response, &String) + 'a,
     ) -> Self {
         self.config.response_callback = Some(Box::new(response_callback));
+        self
+    }
+
+    /// Override whether a root array/object should show direct child elements when collapsed.
+    ///
+    /// If called with `true`, a collapsed root object would render as: `{...}`.
+    ///
+    /// Otherwise, a collapsed root object would render as: `{ "foo": "bar", "baz": {...} }`.
+    pub fn abbreviate_root(mut self, abbreviate_root: bool) -> Self {
+        self.config.abbreviate_root = abbreviate_root;
         self
     }
 


### PR DESCRIPTION
Adds `JsonTree::abbreviate_root` method to override whether a root array/object should show direct child elements when collapsed.
If called with `true`, a collapsed root object would render as: `{...}`.
Otherwise, a collapsed root object would render as: `{ "foo": "bar", "baz": {...} }`.