### PR TITLE
Add truncation option.

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -12,6 +12,7 @@ pub struct JsonTreeConfig<'a> {
     pub(crate) default_expand: DefaultExpand<'a>,
     pub(crate) response_callback: Option<Box<ResponseCallback<'a>>>,
     pub(crate) abbreviate_root: bool,
+    pub(crate) truncate: bool,
 }
 
 /// An interactive JSON tree visualiser.
@@ -63,6 +64,14 @@ impl<'a> JsonTree<'a> {
     /// Otherwise, a collapsed root object would render as: `{ "foo": "bar", "baz": {...} }`.
     pub fn abbreviate_root(mut self, abbreviate_root: bool) -> Self {
         self.config.abbreviate_root = abbreviate_root;
+        self
+    }
+
+    /// Override whether to truncate rendered JSON that exceeds the width of the parent `Ui`.
+    ///
+    /// Does not apply to a collapsed root array/object.
+    pub fn truncate(mut self, truncate: bool) -> Self {
+        self.config.truncate = truncate;
         self
     }
 


### PR DESCRIPTION
Adds a `JsonTree` builder method `truncate` to  override whether to truncate rendered JSON that exceeds the width of the parent `Ui`.
Does not apply to a collapsed root array/object.

Demonstration from the demo with resized windows and `truncate(true)` for the `JsonTree`:


<img width="311" alt="Screenshot 2023-09-27 at 19 35 34" src="https://github.com/dmackdev/egui_json_tree/assets/79006698/8de3fd35-9198-4a3b-adc9-89455a9b7401">

(Modify the rendered `Window` with `min_size(0.0)` and `title_bar(false)`.)