### PR TITLE
Customisable toggle buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ let response = JsonTree::new("customised-tree", &value)
     })
     .default_expand(DefaultExpand::All)
     .abbreviate_root(true) // Show {...} when the root object is collapsed.
+    .toggle_buttons_state(ToggleButtonsState::VisibleDisabled)
     .on_render(|ui, ctx| {
         // Customise rendering of the JsonTree, and/or handle interactions.
         match ctx {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -625,6 +625,29 @@ impl Show for JsonEditorExample {
     }
 }
 
+struct NonInteractiveDemo {
+    value: Value,
+}
+
+impl NonInteractiveDemo {
+    fn new(value: Value) -> Self {
+        Self { value }
+    }
+}
+
+impl Show for NonInteractiveDemo {
+    fn title(&self) -> &'static str {
+        "Non Interactive"
+    }
+
+    fn show(&mut self, ui: &mut Ui) {
+        JsonTree::new(self.title(), &self.value)
+            .default_expand(DefaultExpand::All)
+            .enable_icons(false)
+            .show(ui);
+    }
+}
+
 struct DemoApp {
     examples: Vec<Box<dyn Show>>,
     open_example_idx: Option<usize>,
@@ -655,7 +678,8 @@ impl Default for DemoApp {
                 Box::new(CustomExample::new("Custom Input")),
                 Box::new(SearchExample::new(complex_object.clone())),
                 Box::new(CopyToClipboardExample::new(complex_object.clone())),
-                Box::new(JsonEditorExample::new(complex_object)),
+                Box::new(JsonEditorExample::new(complex_object.clone())),
+                Box::new(NonInteractiveDemo::new(complex_object)),
             ],
             open_example_idx: None,
         }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -12,7 +12,7 @@ use egui_json_tree::{
         DefaultRender, RenderBaseValueContext, RenderContext, RenderExpandableDelimiterContext,
         RenderPropertyContext,
     },
-    DefaultExpand, JsonTree,
+    DefaultExpand, JsonTree, ToggleButtonsState,
 };
 use serde_json::{json, Value};
 
@@ -625,26 +625,50 @@ impl Show for JsonEditorExample {
     }
 }
 
-struct NonInteractiveDemo {
+struct ToggleButtonsCustomisationDemo {
     value: Value,
+    toggle_buttons_state: ToggleButtonsState,
 }
 
-impl NonInteractiveDemo {
+impl ToggleButtonsCustomisationDemo {
     fn new(value: Value) -> Self {
-        Self { value }
+        Self {
+            value,
+            toggle_buttons_state: Default::default(),
+        }
     }
 }
 
-impl Show for NonInteractiveDemo {
+impl Show for ToggleButtonsCustomisationDemo {
     fn title(&self) -> &'static str {
-        "Non Interactive"
+        "Toggle Buttons Customisation"
     }
 
     fn show(&mut self, ui: &mut Ui) {
-        JsonTree::new(self.title(), &self.value)
-            .default_expand(DefaultExpand::All)
-            .enable_icons(false)
-            .show(ui);
+        ui.vertical(|ui| {
+            ui.horizontal(|ui| {
+                ui.selectable_value(
+                    &mut self.toggle_buttons_state,
+                    ToggleButtonsState::VisibleEnabled,
+                    "Visible and enabled",
+                );
+                ui.selectable_value(
+                    &mut self.toggle_buttons_state,
+                    ToggleButtonsState::VisibleDisabled,
+                    "Visible and disabled",
+                );
+                ui.selectable_value(
+                    &mut self.toggle_buttons_state,
+                    ToggleButtonsState::Hidden,
+                    "Hidden",
+                );
+            });
+
+            JsonTree::new("show", &self.value)
+                .default_expand(DefaultExpand::All)
+                .toggle_buttons_state(self.toggle_buttons_state)
+                .show(ui);
+        });
     }
 }
 
@@ -679,7 +703,7 @@ impl Default for DemoApp {
                 Box::new(SearchExample::new(complex_object.clone())),
                 Box::new(CopyToClipboardExample::new(complex_object.clone())),
                 Box::new(JsonEditorExample::new(complex_object.clone())),
-                Box::new(NonInteractiveDemo::new(complex_object)),
+                Box::new(ToggleButtonsCustomisationDemo::new(complex_object)),
             ],
             open_example_idx: None,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod node;
 mod response;
 mod search;
 mod style;
+mod toggle_buttons_state;
 mod tree;
 
 pub mod delimiters;
@@ -86,4 +87,5 @@ pub mod value;
 pub use default_expand::DefaultExpand;
 pub use response::JsonTreeResponse;
 pub use style::JsonTreeStyle;
+pub use toggle_buttons_state::ToggleButtonsState;
 pub use tree::JsonTree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! #       DefaultRender, RenderBaseValueContext, RenderContext, RenderExpandableDelimiterContext,
 //! #       RenderPropertyContext,
 //! #   },
-//! #   DefaultExpand, JsonTree, JsonTreeStyle
+//! #   DefaultExpand, JsonTree, JsonTreeStyle, ToggleButtonsState
 //! # };
 //! # egui::__run_test_ui(|ui| {
 //! let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
@@ -24,6 +24,7 @@
 //!     })
 //!     .default_expand(DefaultExpand::All)
 //!     .abbreviate_root(true) // Show {...} when the root object is collapsed.
+//!     .toggle_buttons_state(ToggleButtonsState::VisibleDisabled)
 //!     .on_render(|ui, ctx| {
 //!         // Customise rendering of the JsonTree, and/or handle interactions.
 //!         match ctx {

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use egui::{collapsing_header::CollapsingState, Id, Ui};
+use egui::{
+    collapsing_header::{paint_default_icon, CollapsingState},
+    Id, Ui,
+};
 
 use crate::{
     delimiters::{SpacingDelimiter, ARRAY_DELIMITERS, OBJECT_DELIMITERS},
@@ -193,223 +196,221 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
         .entry(path_segments.to_vec())
         .or_insert_with(|| make_persistent_id(path_segments));
 
-    let state = CollapsingState::load_with_default_open(ui.ctx(), id_source, default_open);
+    let mut state = CollapsingState::load_with_default_open(ui.ctx(), id_source, default_open);
     let is_expanded = state.is_open();
 
-    state
-        .show_header(ui, |ui| {
-            ui.horizontal_wrapped(|ui| {
-                ui.spacing_mut().item_spacing.x = 0.0;
+    let header_res = ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 0.0;
+        state.show_toggle_button(ui, paint_default_icon);
 
-                if path_segments.is_empty() && !is_expanded {
-                    if *abbreviate_root {
-                        renderer.render_expandable_delimiter(
-                            ui,
-                            RenderExpandableDelimiterContext {
-                                delimiter: delimiters.collapsed,
-                                value: expandable.value,
-                                pointer: JsonPointer(path_segments),
-                                style,
-                            },
-                        );
-                        return;
-                    }
+        if path_segments.is_empty() && !is_expanded {
+            if *abbreviate_root {
+                renderer.render_expandable_delimiter(
+                    ui,
+                    RenderExpandableDelimiterContext {
+                        delimiter: delimiters.collapsed,
+                        value: expandable.value,
+                        pointer: JsonPointer(path_segments),
+                        style,
+                    },
+                );
+                return;
+            }
 
-                    renderer.render_expandable_delimiter(
+            renderer.render_expandable_delimiter(
+                ui,
+                RenderExpandableDelimiterContext {
+                    delimiter: delimiters.opening,
+                    value: expandable.value,
+                    pointer: JsonPointer(path_segments),
+                    style,
+                },
+            );
+            renderer.render_spacing_delimiter(
+                ui,
+                RenderSpacingDelimiterContext {
+                    delimiter: SpacingDelimiter::Empty,
+                    style,
+                },
+            );
+
+            let entries_len = expandable.entries.len();
+
+            for (idx, (property, elem)) in expandable.entries.iter().enumerate() {
+                path_segments.push(*property);
+
+                // Don't show array indices when the array is collapsed.
+                if matches!(expandable.expandable_type, ExpandableType::Object) {
+                    renderer.render_property(
                         ui,
-                        RenderExpandableDelimiterContext {
-                            delimiter: delimiters.opening,
-                            value: expandable.value,
+                        RenderPropertyContext {
+                            property: *property,
+                            value: elem,
                             pointer: JsonPointer(path_segments),
                             style,
+                            search_term: search_term.as_ref(),
                         },
                     );
                     renderer.render_spacing_delimiter(
                         ui,
                         RenderSpacingDelimiterContext {
-                            delimiter: SpacingDelimiter::Empty,
+                            delimiter: SpacingDelimiter::Colon,
                             style,
                         },
                     );
+                }
 
-                    let entries_len = expandable.entries.len();
-
-                    for (idx, (property, elem)) in expandable.entries.iter().enumerate() {
-                        path_segments.push(*property);
-
-                        // Don't show array indices when the array is collapsed.
-                        if matches!(expandable.expandable_type, ExpandableType::Object) {
-                            renderer.render_property(
-                                ui,
-                                RenderPropertyContext {
-                                    property: *property,
-                                    value: elem,
-                                    pointer: JsonPointer(path_segments),
-                                    style,
-                                    search_term: search_term.as_ref(),
-                                },
-                            );
-                            renderer.render_spacing_delimiter(
-                                ui,
-                                RenderSpacingDelimiterContext {
-                                    delimiter: SpacingDelimiter::Colon,
-                                    style,
-                                },
-                            );
-                        }
-
-                        match elem.to_json_tree_value() {
-                            JsonTreeValue::Base(value, display_value, value_type) => {
-                                renderer.render_value(
-                                    ui,
-                                    RenderBaseValueContext {
-                                        value,
-                                        display_value,
-                                        value_type,
-                                        pointer: JsonPointer(path_segments),
-                                        style,
-                                        search_term: search_term.as_ref(),
-                                    },
-                                );
-                            }
-                            JsonTreeValue::Expandable(entries, expandable_type) => {
-                                let nested_delimiters = match expandable_type {
-                                    ExpandableType::Array => &ARRAY_DELIMITERS,
-                                    ExpandableType::Object => &OBJECT_DELIMITERS,
-                                };
-
-                                let delimiter = if entries.is_empty() {
-                                    nested_delimiters.collapsed_empty
-                                } else {
-                                    nested_delimiters.collapsed
-                                };
-
-                                renderer.render_expandable_delimiter(
-                                    ui,
-                                    RenderExpandableDelimiterContext {
-                                        delimiter,
-                                        value: elem,
-                                        pointer: JsonPointer(path_segments),
-                                        style,
-                                    },
-                                );
-                            }
-                        };
-
-                        let spacing = if idx == entries_len - 1 {
-                            SpacingDelimiter::Empty
-                        } else {
-                            SpacingDelimiter::Comma
-                        };
-
-                        renderer.render_spacing_delimiter(
+                match elem.to_json_tree_value() {
+                    JsonTreeValue::Base(value, display_value, value_type) => {
+                        renderer.render_value(
                             ui,
-                            RenderSpacingDelimiterContext {
-                                delimiter: spacing,
-                                style,
-                            },
-                        );
-
-                        path_segments.pop();
-                    }
-
-                    renderer.render_expandable_delimiter(
-                        ui,
-                        RenderExpandableDelimiterContext {
-                            delimiter: delimiters.closing,
-                            value: expandable.value,
-                            pointer: JsonPointer(path_segments),
-                            style,
-                        },
-                    );
-                } else {
-                    if let Some(property) = expandable.parent {
-                        renderer.render_property(
-                            ui,
-                            RenderPropertyContext {
-                                property,
-                                value: expandable.value,
+                            RenderBaseValueContext {
+                                value,
+                                display_value,
+                                value_type,
                                 pointer: JsonPointer(path_segments),
                                 style,
-                                search_term: config.search_term.as_ref(),
-                            },
-                        );
-                        renderer.render_spacing_delimiter(
-                            ui,
-                            RenderSpacingDelimiterContext {
-                                delimiter: SpacingDelimiter::Colon,
-                                style,
+                                search_term: search_term.as_ref(),
                             },
                         );
                     }
-
-                    if is_expanded {
-                        renderer.render_expandable_delimiter(
-                            ui,
-                            RenderExpandableDelimiterContext {
-                                delimiter: delimiters.opening,
-                                value: expandable.value,
-                                pointer: JsonPointer(path_segments),
-                                style,
-                            },
-                        );
-                    } else {
-                        let delimiter = if expandable.entries.is_empty() {
-                            delimiters.collapsed_empty
-                        } else {
-                            delimiters.collapsed
+                    JsonTreeValue::Expandable(entries, expandable_type) => {
+                        let nested_delimiters = match expandable_type {
+                            ExpandableType::Array => &ARRAY_DELIMITERS,
+                            ExpandableType::Object => &OBJECT_DELIMITERS,
                         };
+
+                        let delimiter = if entries.is_empty() {
+                            nested_delimiters.collapsed_empty
+                        } else {
+                            nested_delimiters.collapsed
+                        };
+
                         renderer.render_expandable_delimiter(
                             ui,
                             RenderExpandableDelimiterContext {
                                 delimiter,
-                                value: expandable.value,
+                                value: elem,
                                 pointer: JsonPointer(path_segments),
                                 style,
                             },
                         );
                     }
-                }
-            });
-        })
-        .body(|ui| {
-            for (property, elem) in expandable.entries {
-                let is_expandable = elem.is_expandable();
-
-                path_segments.push(property);
-
-                let mut add_nested_tree = |ui: &mut Ui| {
-                    let nested_tree = JsonTreeNode {
-                        id: expandable.id,
-                        value: elem,
-                        parent: Some(property),
-                    };
-
-                    nested_tree.show_impl(
-                        ui,
-                        path_segments,
-                        path_id_map,
-                        make_persistent_id,
-                        config,
-                        renderer,
-                    );
                 };
 
-                if is_expandable {
-                    add_nested_tree(ui);
+                let spacing = if idx == entries_len - 1 {
+                    SpacingDelimiter::Empty
                 } else {
-                    ui.scope(|ui| {
-                        ui.visuals_mut().indent_has_left_vline = false;
-                        ui.spacing_mut().indent =
-                            ui.spacing().icon_width + ui.spacing().icon_spacing;
+                    SpacingDelimiter::Comma
+                };
 
-                        ui.indent(id_source, add_nested_tree);
-                    });
-                }
+                renderer.render_spacing_delimiter(
+                    ui,
+                    RenderSpacingDelimiterContext {
+                        delimiter: spacing,
+                        style,
+                    },
+                );
 
                 path_segments.pop();
             }
-        });
+
+            renderer.render_expandable_delimiter(
+                ui,
+                RenderExpandableDelimiterContext {
+                    delimiter: delimiters.closing,
+                    value: expandable.value,
+                    pointer: JsonPointer(path_segments),
+                    style,
+                },
+            );
+        } else {
+            if let Some(property) = expandable.parent {
+                renderer.render_property(
+                    ui,
+                    RenderPropertyContext {
+                        property,
+                        value: expandable.value,
+                        pointer: JsonPointer(path_segments),
+                        style,
+                        search_term: config.search_term.as_ref(),
+                    },
+                );
+                renderer.render_spacing_delimiter(
+                    ui,
+                    RenderSpacingDelimiterContext {
+                        delimiter: SpacingDelimiter::Colon,
+                        style,
+                    },
+                );
+            }
+
+            if is_expanded {
+                renderer.render_expandable_delimiter(
+                    ui,
+                    RenderExpandableDelimiterContext {
+                        delimiter: delimiters.opening,
+                        value: expandable.value,
+                        pointer: JsonPointer(path_segments),
+                        style,
+                    },
+                );
+            } else {
+                let delimiter = if expandable.entries.is_empty() {
+                    delimiters.collapsed_empty
+                } else {
+                    delimiters.collapsed
+                };
+                renderer.render_expandable_delimiter(
+                    ui,
+                    RenderExpandableDelimiterContext {
+                        delimiter,
+                        value: expandable.value,
+                        pointer: JsonPointer(path_segments),
+                        style,
+                    },
+                );
+            }
+        }
+    });
+
+    state.show_body_indented(&header_res.response, ui, |ui| {
+        for (property, elem) in expandable.entries {
+            let is_expandable = elem.is_expandable();
+
+            path_segments.push(property);
+
+            let mut add_nested_tree = |ui: &mut Ui| {
+                let nested_tree = JsonTreeNode {
+                    id: expandable.id,
+                    value: elem,
+                    parent: Some(property),
+                };
+
+                nested_tree.show_impl(
+                    ui,
+                    path_segments,
+                    path_id_map,
+                    make_persistent_id,
+                    config,
+                    renderer,
+                );
+            };
+
+            if is_expandable {
+                add_nested_tree(ui);
+            } else {
+                ui.scope(|ui| {
+                    ui.visuals_mut().indent_has_left_vline = false;
+                    ui.spacing_mut().indent = ui.spacing().icon_width + ui.spacing().icon_spacing;
+
+                    ui.indent(id_source, add_nested_tree);
+                });
+            }
+
+            path_segments.pop();
+        }
+    });
 
     if is_expanded {
         ui.horizontal_wrapped(|ui| {

--- a/src/node.rs
+++ b/src/node.rs
@@ -72,6 +72,7 @@ impl<'a, T: ToJsonTreeValue> JsonTreeNode<'a, T> {
             abbreviate_root: config.abbreviate_root,
             style: config.style,
             search_term,
+            enable_icons: config.enable_icons,
         };
 
         // Wrap in a vertical layout in case this tree is placed directly in a horizontal layout,
@@ -178,6 +179,7 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
         abbreviate_root,
         style,
         search_term,
+        enable_icons,
     } = config;
 
     let delimiters = match expandable.expandable_type {
@@ -201,7 +203,10 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
 
     let header_res = ui.horizontal_wrapped(|ui| {
         ui.spacing_mut().item_spacing.x = 0.0;
-        state.show_toggle_button(ui, paint_default_icon);
+
+        ui.add_enabled_ui(*enable_icons, |ui| {
+            state.show_toggle_button(ui, paint_default_icon);
+        });
 
         if path_segments.is_empty() && !is_expanded {
             if *abbreviate_root {
@@ -434,6 +439,7 @@ struct JsonTreeNodeConfig<'a> {
     abbreviate_root: bool,
     style: JsonTreeStyle,
     search_term: Option<SearchTerm>,
+    enable_icons: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/node.rs
+++ b/src/node.rs
@@ -381,7 +381,8 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
         }
     });
 
-    if *toggle_buttons_state == ToggleButtonsState::Hidden {
+    let toggle_buttons_hidden = *toggle_buttons_state == ToggleButtonsState::Hidden;
+    if toggle_buttons_hidden {
         ui.visuals_mut().indent_has_left_vline = true;
         ui.spacing_mut().indent = (ui.spacing().icon_width + ui.spacing().icon_spacing) / 2.0;
     }
@@ -409,14 +410,14 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
                 );
             };
 
-            if is_expandable && *toggle_buttons_state != ToggleButtonsState::Hidden {
+            if is_expandable && !toggle_buttons_hidden {
                 add_nested_tree(ui);
             } else {
                 ui.scope(|ui| {
                     ui.visuals_mut().indent_has_left_vline = false;
                     ui.spacing_mut().indent = ui.spacing().icon_width + ui.spacing().icon_spacing;
 
-                    if *toggle_buttons_state == ToggleButtonsState::Hidden {
+                    if toggle_buttons_hidden {
                         ui.spacing_mut().indent /= 2.0;
                     }
 
@@ -430,7 +431,7 @@ fn show_expandable<'a, 'b, T: ToJsonTreeValue>(
 
     if is_expanded {
         ui.horizontal_wrapped(|ui| {
-            if *toggle_buttons_state != ToggleButtonsState::Hidden {
+            if !toggle_buttons_hidden {
                 let indent = ui.spacing().icon_width / 2.0;
                 ui.add_space(indent);
             }

--- a/src/toggle_buttons_state.rs
+++ b/src/toggle_buttons_state.rs
@@ -1,0 +1,18 @@
+/// Setting for the visibility and interactivity of the toggle buttons for expanding/collapsing objects and arrays.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ToggleButtonsState {
+    #[default]
+    VisibleEnabled,
+    VisibleDisabled,
+    Hidden,
+}
+
+impl ToggleButtonsState {
+    pub(crate) fn enabled(&self) -> Option<bool> {
+        match self {
+            ToggleButtonsState::VisibleEnabled => Some(true),
+            ToggleButtonsState::VisibleDisabled => Some(false),
+            ToggleButtonsState::Hidden => None,
+        }
+    }
+}

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -2,7 +2,7 @@ use crate::{
     node::JsonTreeNode,
     render::{JsonTreeRenderer, RenderContext},
     value::ToJsonTreeValue,
-    DefaultExpand, JsonTreeResponse, JsonTreeStyle,
+    DefaultExpand, JsonTreeResponse, JsonTreeStyle, ToggleButtonsState,
 };
 use egui::{Id, Ui};
 use std::hash::Hash;
@@ -12,7 +12,7 @@ pub(crate) struct JsonTreeConfig<'a, T: ToJsonTreeValue> {
     pub(crate) default_expand: DefaultExpand<'a>,
     pub(crate) abbreviate_root: bool,
     pub(crate) renderer: JsonTreeRenderer<'a, T>,
-    pub(crate) enable_icons: bool,
+    pub(crate) toggle_buttons_state: ToggleButtonsState,
 }
 
 impl<'a, T: ToJsonTreeValue> Default for JsonTreeConfig<'a, T> {
@@ -22,7 +22,7 @@ impl<'a, T: ToJsonTreeValue> Default for JsonTreeConfig<'a, T> {
             default_expand: Default::default(),
             abbreviate_root: Default::default(),
             renderer: Default::default(),
-            enable_icons: true,
+            toggle_buttons_state: Default::default(),
         }
     }
 }
@@ -107,8 +107,9 @@ impl<'a, T: ToJsonTreeValue> JsonTree<'a, T> {
         self
     }
 
-    pub fn enable_icons(mut self, enable_icons: bool) -> Self {
-        self.config.enable_icons = enable_icons;
+    /// Override the visibility and interactivity of the toggle buttons for expanding/collapsing objects and arrays.
+    pub fn toggle_buttons_state(mut self, toggle_buttons_state: ToggleButtonsState) -> Self {
+        self.config.toggle_buttons_state = toggle_buttons_state;
         self
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -12,6 +12,7 @@ pub(crate) struct JsonTreeConfig<'a, T: ToJsonTreeValue> {
     pub(crate) default_expand: DefaultExpand<'a>,
     pub(crate) abbreviate_root: bool,
     pub(crate) renderer: JsonTreeRenderer<'a, T>,
+    pub(crate) enable_icons: bool,
 }
 
 impl<'a, T: ToJsonTreeValue> Default for JsonTreeConfig<'a, T> {
@@ -21,6 +22,7 @@ impl<'a, T: ToJsonTreeValue> Default for JsonTreeConfig<'a, T> {
             default_expand: Default::default(),
             abbreviate_root: Default::default(),
             renderer: Default::default(),
+            enable_icons: true,
         }
     }
 }
@@ -102,6 +104,11 @@ impl<'a, T: ToJsonTreeValue> JsonTree<'a, T> {
     /// Otherwise, a collapsed root object would render as: `{ "foo": "bar", "baz": {...} }`.
     pub fn abbreviate_root(mut self, abbreviate_root: bool) -> Self {
         self.config.abbreviate_root = abbreviate_root;
+        self
+    }
+
+    pub fn enable_icons(mut self, enable_icons: bool) -> Self {
+        self.config.enable_icons = enable_icons;
         self
     }
 


### PR DESCRIPTION
Closes https://github.com/dmackdev/egui_json_tree/issues/22.

- Adds `ToggleButtonsState` enum to control visibility/interactivity of toggle buttons via 3 states: visible and enabled, visible and disabled, and hidden.
- Adds `JsonTree::toggle_buttons_state` builder method.
- Adds "Toggle Buttons Customisation" demo.

https://github.com/user-attachments/assets/41e8aa79-ad67-46af-b074-dde6d0f14435