### PR TITLE
Automatic dark/light theming

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ JsonTree::new("simple-tree", &value).show(ui);
 // Customised:
 let response = JsonTree::new("customised-tree", &value)
     .style(JsonTreeStyle {
-        bool_color: Color32::YELLOW,
+        visuals: Some(JsonTreeVisuals {
+            bool_color: Color32::YELLOW,
+            ..Default::default()
+        }),
         ..Default::default()
     })
     .default_expand(DefaultExpand::All)

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -3,6 +3,7 @@ use apps::{
     editor::JsonEditorExample, search::SearchExample,
     toggle_buttons::ToggleButtonsCustomisationDemo, Example, Show,
 };
+use egui::global_theme_preference_buttons;
 use serde_json::json;
 
 mod apps;
@@ -50,6 +51,12 @@ impl eframe::App for DemoApp {
         egui::SidePanel::left("left-panel")
             .resizable(false)
             .show(ctx, |ui| {
+                egui::TopBottomPanel::top("theme-preference-top-panel")
+                    .frame(egui::Frame::side_top_panel(&ctx.style()).inner_margin(10.0))
+                    .show_inside(ui, |ui| {
+                        global_theme_preference_buttons(ui);
+                    });
+                ui.add_space(10.0);
                 ui.with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {
                     for (idx, example) in self.examples.iter().enumerate() {
                         let is_open = self

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -12,10 +12,8 @@ struct DemoApp {
     open_example_idx: Option<usize>,
 }
 
-impl DemoApp {
-    fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        cc.egui_ctx.set_theme(egui::Theme::Dark);
-
+impl Default for DemoApp {
+    fn default() -> Self {
         let complex_object = json!({"foo": [1, 2, [3]], "bar": { "qux" : false, "thud": { "a/b": [4, 5, { "m~n": "Greetings!" }]}, "grep": 21}, "baz": null});
 
         Self {
@@ -104,7 +102,7 @@ fn main() {
     let _ = eframe::run_native(
         "egui JSON Tree Demo",
         eframe::NativeOptions::default(),
-        Box::new(|cc| Ok(Box::new(DemoApp::new(cc)))),
+        Box::new(|_cc| Ok(Box::<DemoApp>::default())),
     );
 }
 
@@ -133,7 +131,7 @@ fn main() {
             .start(
                 canvas,
                 web_options,
-                Box::new(|cc| Ok(Box::new(DemoApp::new(cc)))),
+                Box::new(|_cc| Ok(Box::<DemoApp>::default())),
             )
             .await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! #       DefaultRender, RenderBaseValueContext, RenderContext, RenderExpandableDelimiterContext,
 //! #       RenderPropertyContext,
 //! #   },
-//! #   DefaultExpand, JsonTree, JsonTreeStyle, ToggleButtonsState
+//! #   DefaultExpand, JsonTree, JsonTreeStyle, JsonTreeVisuals, ToggleButtonsState
 //! # };
 //! # egui::__run_test_ui(|ui| {
 //! let value = serde_json::json!({ "foo": "bar", "fizz": [1, 2, 3]});
@@ -24,8 +24,11 @@
 //! // Customised:
 //! let response = JsonTree::new("customised-tree", &value)
 //!     .style(JsonTreeStyle {
-//!         bool_color: Color32::YELLOW,
-//!         ..Default::default()
+//!       visuals: Some(JsonTreeVisuals {
+//!           bool_color: Color32::YELLOW,
+//!           ..Default::default()
+//!       }),
+//!       ..Default::default()
 //!     })
 //!     .default_expand(DefaultExpand::All)
 //!     .abbreviate_root(true) // Show {...} when the root object is collapsed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,6 @@ pub mod value;
 
 pub use default_expand::DefaultExpand;
 pub use response::JsonTreeResponse;
-pub use style::JsonTreeStyle;
+pub use style::{JsonTreeStyle, JsonTreeVisuals};
 pub use toggle_buttons_state::ToggleButtonsState;
 pub use tree::JsonTree;

--- a/src/style.rs
+++ b/src/style.rs
@@ -2,45 +2,24 @@ use egui::{Color32, FontId, TextStyle, Ui};
 
 use crate::value::BaseValueType;
 
-/// Contains coloring parameters for JSON syntax highlighting, and search match highlighting.
-#[derive(Debug, Clone, Hash)]
+/// Styling configuration to control the appearance of the [`JsonTree`](crate::JsonTree).
+#[derive(Debug, Clone, Hash, Default)]
 pub struct JsonTreeStyle {
-    pub object_key_color: Color32,
-    pub array_idx_color: Color32,
-    pub null_color: Color32,
-    pub bool_color: Color32,
-    pub number_color: Color32,
-    pub string_color: Color32,
-    pub highlight_color: Color32,
-    /// The text color for array brackets, object braces, colons and commas.
-    pub punctuation_color: Color32,
-    /// The font to use. Defaults to `TextStyle::Monospace.resolve(ui.style())`.
+    /// The colors to use. If not set, defaults to either a dark or light color scheme, depending on [`egui::Visuals::dark_mode`].
+    pub visuals: Option<JsonTreeVisuals>,
+    /// The font to use. If not set, defaults to `TextStyle::Monospace.resolve(ui.style())`.
     pub font_id: Option<FontId>,
 }
 
-impl Default for JsonTreeStyle {
-    fn default() -> Self {
-        Self {
-            object_key_color: Color32::from_rgb(161, 206, 235),
-            array_idx_color: Color32::from_rgb(96, 103, 168),
-            null_color: Color32::from_rgb(103, 154, 209),
-            bool_color: Color32::from_rgb(103, 154, 209),
-            number_color: Color32::from_rgb(181, 199, 166),
-            string_color: Color32::from_rgb(194, 146, 122),
-            highlight_color: Color32::from_rgba_premultiplied(72, 72, 72, 50),
-            punctuation_color: Color32::from_gray(140),
-            font_id: None,
-        }
-    }
-}
-
 impl JsonTreeStyle {
-    pub fn get_color(&self, base_value_type: &BaseValueType) -> Color32 {
-        match base_value_type {
-            BaseValueType::Null => self.null_color,
-            BaseValueType::Bool => self.bool_color,
-            BaseValueType::Number => self.number_color,
-            BaseValueType::String => self.string_color,
+    /// Resolves the [`JsonTreeVisuals`] color scheme to use.
+    pub fn visuals(&self, ui: &Ui) -> &JsonTreeVisuals {
+        if let Some(visuals) = &self.visuals {
+            visuals
+        } else if ui.visuals().dark_mode {
+            &JsonTreeVisuals::DARK
+        } else {
+            &JsonTreeVisuals::LIGHT
         }
     }
 
@@ -49,6 +28,59 @@ impl JsonTreeStyle {
             font_id.clone()
         } else {
             TextStyle::Monospace.resolve(ui.style())
+        }
+    }
+}
+
+/// Colors for JSON syntax highlighting, and search match highlighting.
+#[derive(Debug, Clone, Hash)]
+pub struct JsonTreeVisuals {
+    pub object_key_color: Color32,
+    pub array_idx_color: Color32,
+    pub null_color: Color32,
+    pub bool_color: Color32,
+    pub number_color: Color32,
+    pub string_color: Color32,
+    pub highlight_color: Color32,
+    /// The color for array brackets, object braces, colons and commas.
+    pub punctuation_color: Color32,
+}
+
+impl Default for JsonTreeVisuals {
+    fn default() -> Self {
+        Self::DARK
+    }
+}
+
+impl JsonTreeVisuals {
+    pub const DARK: Self = Self {
+        object_key_color: Color32::from_rgb(161, 206, 235),
+        array_idx_color: Color32::from_rgb(96, 103, 168),
+        null_color: Color32::from_rgb(103, 154, 209),
+        bool_color: Color32::from_rgb(103, 154, 209),
+        number_color: Color32::from_rgb(181, 199, 166),
+        string_color: Color32::from_rgb(194, 146, 122),
+        highlight_color: Color32::from_rgba_premultiplied(72, 72, 72, 50),
+        punctuation_color: Color32::from_gray(140),
+    };
+
+    pub const LIGHT: Self = Self {
+        object_key_color: Color32::from_rgb(23, 74, 151),
+        array_idx_color: Color32::from_rgb(158, 46, 103),
+        null_color: Color32::from_rgb(40, 34, 245),
+        bool_color: Color32::from_rgb(40, 34, 245),
+        number_color: Color32::from_rgb(1, 97, 63),
+        string_color: Color32::from_rgb(149, 38, 31),
+        highlight_color: Color32::from_rgba_premultiplied(181, 213, 251, 255),
+        punctuation_color: Color32::from_gray(70),
+    };
+
+    pub fn get_color(&self, base_value_type: &BaseValueType) -> Color32 {
+        match base_value_type {
+            BaseValueType::Null => self.null_color,
+            BaseValueType::Bool => self.bool_color,
+            BaseValueType::Number => self.number_color,
+            BaseValueType::String => self.string_color,
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dmackdev/egui_json_tree/issues/27.

- **Breaking**: Moves colours from `JsonTreeStyle` into `Option<JsonTreeVisuals>`. 
- Exposes default light colour scheme `JsonTreeVisuals::LIGHT`.
- Resolves default colour scheme to use based on `egui::Visuals::dark_mode` if `JsonTreeStyle::visuals` is not set.
- Updates demo with theme preference radio buttons.


https://github.com/user-attachments/assets/36437834-267e-4079-a9b9-f22a0d0b7d88

