### PR TITLE
support truncation and wrapping options

### DIFF
--- a/examples/demo/src/apps/mod.rs
+++ b/examples/demo/src/apps/mod.rs
@@ -7,6 +7,7 @@ pub mod custom_input;
 pub mod editor;
 pub mod search;
 pub mod toggle_buttons;
+pub mod wrapping;
 
 pub trait Show {
     fn title(&self) -> &'static str;

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -20,6 +20,7 @@ impl WrappingExample {
             wrap: JsonTreeWrapping {
                 max_rows: 1,
                 max_width: JsonTreeMaxWidth::UiAvailableWidth,
+                break_anywhere: true,
             },
             use_maximum_max_rows: false,
         }
@@ -59,6 +60,7 @@ impl Show for WrappingExample {
         {
             self.wrap.max_rows = usize::MAX;
         }
+        ui.add_space(10.0);
 
         ui.label(egui::RichText::new("Max Width:").monospace());
         ui.horizontal(|ui| {
@@ -86,6 +88,13 @@ impl Show for WrappingExample {
         {
             self.wrap.max_width = JsonTreeMaxWidth::UiAvailableWidth;
         }
+        ui.add_space(10.0);
+
+        ui.horizontal(|ui| {
+            ui.label(egui::RichText::new("Break anywhere:").monospace());
+            ui.checkbox(&mut self.wrap.break_anywhere, "");
+        });
+        ui.separator();
 
         JsonTree::new(self.title(), &self.value)
             .style(JsonTreeStyle::new().wrap(JsonTreeWrappingParams {

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -43,7 +43,7 @@ impl Show for WrappingExample {
         ui.label(egui::RichText::new("Max Width:").monospace());
         ui.horizontal(|ui| {
             if ui
-                .selectable_label(
+                .radio(
                     matches!(self.state.max_width, JsonTreeMaxWidth::Pt(_)),
                     "Points",
                 )
@@ -59,7 +59,7 @@ impl Show for WrappingExample {
         });
 
         if ui
-            .selectable_label(
+            .radio(
                 matches!(self.state.max_width, JsonTreeMaxWidth::UiAvailableWidth),
                 "Available Width",
             )

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -1,7 +1,7 @@
 use egui::{DragValue, Ui};
 use egui_json_tree::{
     DefaultExpand, JsonTree, JsonTreeMaxWidth, JsonTreeStyle, JsonTreeWrapping,
-    JsonTreeWrappingParams,
+    JsonTreeWrappingConfig,
 };
 use serde_json::Value;
 
@@ -95,11 +95,13 @@ impl Show for WrappingExample {
         ui.separator();
 
         JsonTree::new(self.title(), &self.value)
-            .style(JsonTreeStyle::new().wrap(JsonTreeWrappingParams {
-                value_no_parent: self.wrap,
-                value_expanded_parent: self.wrap,
-                value_collapsed_root: self.wrap,
-            }))
+            .style(
+                JsonTreeStyle::new().wrapping_config(JsonTreeWrappingConfig {
+                    value_when_root: self.wrap,
+                    value_with_expanded_parent: self.wrap,
+                    value_in_collapsed_root: self.wrap,
+                }),
+            )
             .default_expand(DefaultExpand::All)
             .show(ui);
     }

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -52,9 +52,7 @@ impl Show for WrappingExample {
                 self.state.max_width = JsonTreeMaxWidth::Pt(100.0);
             }
             if let JsonTreeMaxWidth::Pt(ref mut pts) = &mut self.state.max_width {
-                if pts.is_finite() {
-                    ui.add(DragValue::new(pts).speed(10.0).range(100.0..=10000.0));
-                }
+                ui.add(DragValue::new(pts).speed(10.0).range(100.0..=10000.0));
             }
         });
 

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -1,0 +1,90 @@
+use egui::{DragValue, Ui};
+use egui_json_tree::{
+    DefaultExpand, JsonTree, JsonTreeMaxWidth, JsonTreeStyle, JsonTreeWrapping,
+    JsonTreeWrappingParams,
+};
+use serde_json::Value;
+
+use super::Show;
+
+pub struct WrappingExample {
+    value: Value,
+    state: JsonTreeWrapping,
+}
+
+impl WrappingExample {
+    pub fn new(value: Value) -> Self {
+        Self {
+            value,
+            state: JsonTreeWrapping {
+                max_rows: 1,
+                max_width: JsonTreeMaxWidth::UiAvailableWidth,
+            },
+        }
+    }
+}
+
+impl Show for WrappingExample {
+    fn title(&self) -> &'static str {
+        "Wrapping"
+    }
+
+    fn show(&mut self, ui: &mut Ui) {
+        ui.hyperlink_to("Source", "https://github.com/dmackdev/egui_json_tree/blob/master/examples/demo/src/apps/wrapping.rs");
+        ui.add_space(10.0);
+
+        ui.label(egui::RichText::new("Max Rows:").monospace());
+        ui.add(
+            DragValue::new(&mut self.state.max_rows)
+                .speed(0.1)
+                .range(1..=5),
+        );
+
+        ui.label(egui::RichText::new("Max Width:").monospace());
+        ui.horizontal(|ui| {
+            if ui
+                .selectable_label(
+                    matches!(self.state.max_width, JsonTreeMaxWidth::Pt(pts) if pts.is_finite()),
+                    "Points",
+                )
+                .clicked()
+            {
+                self.state.max_width = JsonTreeMaxWidth::Pt(100.0);
+            }
+            if let JsonTreeMaxWidth::Pt(ref mut pts) = &mut self.state.max_width {
+                if pts.is_finite() {
+                    ui.add(DragValue::new(pts).speed(10.0).range(100.0..=10000.0));
+                }
+            }
+        });
+
+        if ui
+            .selectable_label(
+                matches!(self.state.max_width, JsonTreeMaxWidth::UiAvailableWidth),
+                "Available Width",
+            )
+            .clicked()
+        {
+            self.state.max_width = JsonTreeMaxWidth::UiAvailableWidth;
+        }
+
+        if ui
+            .selectable_label(
+                matches!(self.state.max_width, JsonTreeMaxWidth::Pt(pts) if pts.is_infinite()),
+                "Infinite",
+            )
+            .clicked()
+        {
+            self.state.max_width = JsonTreeMaxWidth::Pt(f32::INFINITY);
+        }
+
+        JsonTree::new(self.title(), &self.value)
+            .style(JsonTreeStyle::new().wrap(JsonTreeWrappingParams {
+                value_no_parent: self.state,
+                value_expanded_parent: self.state,
+                value_collapsed_root: self.state,
+            }))
+            .default_expand(DefaultExpand::All)
+            .show(ui);
+    }
+}

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -66,15 +66,15 @@ impl Show for WrappingExample {
         ui.horizontal(|ui| {
             if ui
                 .radio(
-                    matches!(self.wrap.max_width, JsonTreeMaxWidth::Pt(_)),
+                    matches!(self.wrap.max_width, JsonTreeMaxWidth::Points(_)),
                     "Points",
                 )
                 .clicked()
-                && !matches!(self.wrap.max_width, JsonTreeMaxWidth::Pt(_))
+                && !matches!(self.wrap.max_width, JsonTreeMaxWidth::Points(_))
             {
-                self.wrap.max_width = JsonTreeMaxWidth::Pt(100.0);
+                self.wrap.max_width = JsonTreeMaxWidth::Points(100.0);
             }
-            if let JsonTreeMaxWidth::Pt(ref mut pts) = &mut self.wrap.max_width {
+            if let JsonTreeMaxWidth::Points(ref mut pts) = &mut self.wrap.max_width {
                 ui.add(DragValue::new(pts).speed(10.0).range(100.0..=10000.0));
             }
         });

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -90,10 +90,8 @@ impl Show for WrappingExample {
         }
         ui.add_space(10.0);
 
-        ui.horizontal(|ui| {
-            ui.label(egui::RichText::new("Break anywhere:").monospace());
-            ui.checkbox(&mut self.wrap.break_anywhere, "");
-        });
+        ui.checkbox(&mut self.wrap.break_anywhere, "Break anywhere");
+
         ui.separator();
 
         JsonTree::new(self.title(), &self.value)

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -44,7 +44,7 @@ impl Show for WrappingExample {
         ui.horizontal(|ui| {
             if ui
                 .selectable_label(
-                    matches!(self.state.max_width, JsonTreeMaxWidth::Pt(pts) if pts.is_finite()),
+                    matches!(self.state.max_width, JsonTreeMaxWidth::Pt(_)),
                     "Points",
                 )
                 .clicked()
@@ -66,16 +66,6 @@ impl Show for WrappingExample {
             .clicked()
         {
             self.state.max_width = JsonTreeMaxWidth::UiAvailableWidth;
-        }
-
-        if ui
-            .selectable_label(
-                matches!(self.state.max_width, JsonTreeMaxWidth::Pt(pts) if pts.is_infinite()),
-                "Infinite",
-            )
-            .clicked()
-        {
-            self.state.max_width = JsonTreeMaxWidth::Pt(f32::INFINITY);
         }
 
         JsonTree::new(self.title(), &self.value)

--- a/examples/demo/src/apps/wrapping.rs
+++ b/examples/demo/src/apps/wrapping.rs
@@ -10,7 +10,7 @@ use super::Show;
 pub struct WrappingExample {
     value: Value,
     wrap: JsonTreeWrapping,
-    use_maximum_max_rows: bool,
+    use_custom_max_rows: bool,
 }
 
 impl WrappingExample {
@@ -22,7 +22,7 @@ impl WrappingExample {
                 max_width: JsonTreeMaxWidth::UiAvailableWidth,
                 break_anywhere: true,
             },
-            use_maximum_max_rows: false,
+            use_custom_max_rows: true,
         }
     }
 }
@@ -36,16 +36,39 @@ impl Show for WrappingExample {
         ui.hyperlink_to("Source", "https://github.com/dmackdev/egui_json_tree/blob/master/examples/demo/src/apps/wrapping.rs");
         ui.add_space(10.0);
 
+        self.show_max_rows_controls(ui);
+        ui.add_space(10.0);
+
+        self.show_max_width_controls(ui);
+        ui.add_space(10.0);
+
+        ui.checkbox(&mut self.wrap.break_anywhere, "Break anywhere");
+        ui.separator();
+
+        let wrapping_config = JsonTreeWrappingConfig {
+            value_when_root: self.wrap,
+            value_with_expanded_parent: self.wrap,
+            value_in_collapsed_root: self.wrap,
+        };
+        JsonTree::new(self.title(), &self.value)
+            .style(JsonTreeStyle::new().wrapping_config(wrapping_config))
+            .default_expand(DefaultExpand::All)
+            .show(ui);
+    }
+}
+
+impl WrappingExample {
+    fn show_max_rows_controls(&mut self, ui: &mut Ui) {
         ui.label(egui::RichText::new("Max Rows:").monospace());
         ui.horizontal(|ui| {
             if ui
-                .radio_value(&mut self.use_maximum_max_rows, false, "Custom")
+                .radio_value(&mut self.use_custom_max_rows, true, "Custom")
                 .changed()
             {
                 self.wrap.max_rows = 1;
             }
 
-            if !self.use_maximum_max_rows {
+            if self.use_custom_max_rows {
                 ui.add(
                     DragValue::new(&mut self.wrap.max_rows)
                         .speed(0.1)
@@ -55,13 +78,14 @@ impl Show for WrappingExample {
         });
 
         if ui
-            .radio_value(&mut self.use_maximum_max_rows, true, "usize::MAX")
+            .radio_value(&mut self.use_custom_max_rows, false, "usize::MAX")
             .clicked()
         {
             self.wrap.max_rows = usize::MAX;
         }
-        ui.add_space(10.0);
+    }
 
+    fn show_max_width_controls(&mut self, ui: &mut Ui) {
         ui.label(egui::RichText::new("Max Width:").monospace());
         ui.horizontal(|ui| {
             if ui
@@ -88,21 +112,5 @@ impl Show for WrappingExample {
         {
             self.wrap.max_width = JsonTreeMaxWidth::UiAvailableWidth;
         }
-        ui.add_space(10.0);
-
-        ui.checkbox(&mut self.wrap.break_anywhere, "Break anywhere");
-
-        ui.separator();
-
-        JsonTree::new(self.title(), &self.value)
-            .style(
-                JsonTreeStyle::new().wrapping_config(JsonTreeWrappingConfig {
-                    value_when_root: self.wrap,
-                    value_with_expanded_parent: self.wrap,
-                    value_in_collapsed_root: self.wrap,
-                }),
-            )
-            .default_expand(DefaultExpand::All)
-            .show(ui);
     }
 }

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -77,21 +77,23 @@ impl eframe::App for DemoApp {
 
                 ui.label(egui::RichText::new("Examples").monospace());
                 ui.with_layout(egui::Layout::top_down_justified(egui::Align::LEFT), |ui| {
-                    egui::ScrollArea::vertical().show(ui, |ui| {
-                        for (idx, example) in self.examples.iter().enumerate() {
-                            let is_open = self
-                                .open_example_idx
-                                .is_some_and(|open_idx| open_idx == idx);
+                    egui::ScrollArea::vertical()
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            for (idx, example) in self.examples.iter().enumerate() {
+                                let is_open = self
+                                    .open_example_idx
+                                    .is_some_and(|open_idx| open_idx == idx);
 
-                            if ui.selectable_label(is_open, example.title()).clicked() {
-                                if is_open {
-                                    self.open_example_idx = None;
-                                } else {
-                                    self.open_example_idx = Some(idx);
+                                if ui.selectable_label(is_open, example.title()).clicked() {
+                                    if is_open {
+                                        self.open_example_idx = None;
+                                    } else {
+                                        self.open_example_idx = Some(idx);
+                                    }
                                 }
                             }
-                        }
-                    });
+                        });
                 });
             });
 
@@ -115,9 +117,11 @@ impl eframe::App for DemoApp {
         egui::CentralPanel::default().show(ctx, |ui| {
             match example {
                 Some(example) => {
-                    egui::ScrollArea::vertical().show(ui, |ui| {
-                        example.show(ui);
-                    });
+                    egui::ScrollArea::vertical()
+                        .auto_shrink([false, false])
+                        .show(ui, |ui| {
+                            example.show(ui);
+                        });
                 }
                 None => {
                     if !self.left_sidebar_expanded {

--- a/examples/demo/src/main.rs
+++ b/examples/demo/src/main.rs
@@ -1,7 +1,7 @@
 use apps::{
     copy_to_clipboard::CopyToClipboardExample, custom_input::CustomExample,
     editor::JsonEditorExample, search::SearchExample,
-    toggle_buttons::ToggleButtonsCustomisationDemo, Example, Show,
+    toggle_buttons::ToggleButtonsCustomisationDemo, wrapping::WrappingExample, Example, Show,
 };
 use serde_json::json;
 
@@ -16,6 +16,20 @@ struct DemoApp {
 impl Default for DemoApp {
     fn default() -> Self {
         let complex_object = json!({"foo": [1, 2, [3]], "bar": { "qux" : false, "thud": { "a/b": [4, 5, { "m~n": "Greetings!" }]}, "grep": 21}, "baz": null});
+        let long_strings_object = json!({
+          "baz": "Ullamco ipsum proident occaecat eiusmod ea aute ex non cupidatat laboris duis amet cupidatat. Ullamco sint do enim consectetur Lorem occaecat mollit. Aliquip voluptate ullamco consectetur adipisicing elit fugiat labore laboris. Occaecat non incididunt duis consectetur aliquip dolore cillum eiusmod. Qui sunt est excepteur laborum.",
+          "bar": [
+            "Laboris id occaecat sit quis aliqua et. Fugiat nisi nulla nostrud voluptate id enim do esse deserunt non culpa incididunt eiusmod. Minim nulla reprehenderit irure duis amet commodo commodo aliquip ut. Lorem amet ipsum excepteur consectetur qui dolore. In occaecat dolor ullamco voluptate dolore qui incididunt occaecat pariatur est qui aliquip labore non.",
+            "Velit ex nisi in et enim veniam ullamco reprehenderit consectetur Lorem. Dolor commodo pariatur Lorem proident. Ad minim aliquip excepteur officia consequat nulla mollit adipisicing ut veniam Lorem. Sint mollit occaecat velit do. Nulla aute Lorem non excepteur.",
+            "Officia culpa in adipisicing sunt qui culpa voluptate ad veniam adipisicing anim ex aute. Laboris ipsum id est cillum minim quis sint ex culpa dolore minim. Lorem excepteur deserunt voluptate minim consequat qui quis enim. Do non irure pariatur exercitation commodo laboris sit. Sunt magna nulla magna Lorem reprehenderit dolore et tempor Lorem esse quis exercitation tempor commodo."
+          ],
+          "qux": {
+            "thud": "Et mollit occaecat et aliqua officia adipisicing adipisicing. Fugiat cillum dolor eu laborum cupidatat aliqua et reprehenderit do laboris velit in. Dolor voluptate Lorem pariatur voluptate enim labore in et pariatur consequat esse elit. Do qui aute proident in aliquip. Ea velit quis ex enim proident tempor laboris exercitation aute consectetur minim.",
+            "fizz": {
+              "buzz": "Sunt Lorem officia reprehenderit ea esse aliqua in veniam. Do irure amet dolore magna amet tempor anim sit irure tempor proident laborum dolore. Aute et ullamco eiusmod culpa et esse. Minim ut elit laboris est. Est mollit et mollit dolore ea adipisicing nostrud excepteur."
+            }
+          }
+        });
 
         Self {
             examples: vec![
@@ -40,6 +54,7 @@ impl Default for DemoApp {
                 Box::new(CopyToClipboardExample::new(complex_object.clone())),
                 Box::new(JsonEditorExample::new(complex_object.clone())),
                 Box::new(ToggleButtonsCustomisationDemo::new(complex_object)),
+                Box::new(WrappingExample::new(long_strings_object)),
             ],
             open_example_idx: None,
             left_sidebar_expanded: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub mod value;
 pub use default_expand::DefaultExpand;
 pub use response::JsonTreeResponse;
 pub use style::{
-    JsonTreeMaxWidth, JsonTreeStyle, JsonTreeVisuals, JsonTreeWrapping, JsonTreeWrappingParams,
+    JsonTreeMaxWidth, JsonTreeStyle, JsonTreeVisuals, JsonTreeWrapping, JsonTreeWrappingConfig,
 };
 pub use toggle_buttons_state::ToggleButtonsState;
 pub use tree::JsonTree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ pub mod value;
 
 pub use default_expand::DefaultExpand;
 pub use response::JsonTreeResponse;
-pub use style::{JsonTreeStyle, JsonTreeVisuals};
+pub use style::{
+    JsonTreeMaxWidth, JsonTreeStyle, JsonTreeVisuals, JsonTreeWrapping, JsonTreeWrappingParams,
+};
 pub use toggle_buttons_state::ToggleButtonsState;
 pub use tree::JsonTree;

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@ use crate::{
     delimiters::{SpacingDelimiter, ARRAY_DELIMITERS, OBJECT_DELIMITERS},
     pointer::{JsonPointer, JsonPointerSegment},
     render::{
-        JsonTreeRenderer, RenderBaseValueContext, RenderExpandableDelimiterContext,
+        JsonTreeRenderer, ParentStatus, RenderBaseValueContext, RenderExpandableDelimiterContext,
         RenderPropertyContext, RenderSpacingDelimiterContext,
     },
     response::JsonTreeResponse,
@@ -94,7 +94,7 @@ impl<'a, 'b, T: ToJsonTreeValue> JsonTreeNode<'a, 'b, T> {
     ) {
         match self.value.to_json_tree_value() {
             JsonTreeValue::Base(value, display_value, value_type) => {
-                ui.horizontal_wrapped(|ui| {
+                ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
 
                     if let Some(property) = self.parent {
@@ -127,6 +127,11 @@ impl<'a, 'b, T: ToJsonTreeValue> JsonTreeNode<'a, 'b, T> {
                             pointer: JsonPointer(path_segments),
                             style: &self.config.style,
                             search_term: self.config.search_term.as_ref(),
+                            parent_status: if self.parent.is_some() {
+                                ParentStatus::ExpandedParent
+                            } else {
+                                ParentStatus::NoParent
+                            },
                         },
                     );
                 });
@@ -259,6 +264,7 @@ impl<'a, 'b, T: ToJsonTreeValue> JsonTreeNode<'a, 'b, T> {
                                     pointer: JsonPointer(path_segments),
                                     style,
                                     search_term: search_term.as_ref(),
+                                    parent_status: ParentStatus::CollapsedRoot,
                                 },
                             );
                         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -94,6 +94,8 @@ impl<'a, 'b, T: ToJsonTreeValue> JsonTreeNode<'a, 'b, T> {
     ) {
         match self.value.to_json_tree_value() {
             JsonTreeValue::Base(value, display_value, value_type) => {
+                // Use horizontal instead of horizontal_wrapped so that the
+                // base value always starts inline with the property and not below it.
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 0.0;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -452,5 +452,6 @@ fn render_delimiter(ui: &mut Ui, style: &JsonTreeStyle, delimiter_str: &str) -> 
 }
 
 fn render_job(ui: &mut Ui, job: LayoutJob) -> Response {
-    ui.add(Label::new(job).sense(Sense::click_and_drag()))
+    let galley = ui.fonts(|f| f.layout_job(job));
+    ui.add(Label::new(galley).sense(Sense::click_and_drag()))
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -85,7 +85,7 @@ impl JsonTreeStyle {
         };
 
         let max_width = match wrap.max_width {
-            JsonTreeMaxWidth::Pt(max_width) => max_width,
+            JsonTreeMaxWidth::Points(max_width) => max_width,
             JsonTreeMaxWidth::UiAvailableWidth => ui.available_width(),
         };
 
@@ -179,6 +179,6 @@ impl Default for JsonTreeWrapping {
 
 #[derive(Debug, Clone, Copy)]
 pub enum JsonTreeMaxWidth {
-    Pt(f32),
+    Points(f32),
     UiAvailableWidth,
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -165,10 +165,11 @@ pub struct JsonTreeWrapping {
 
 impl Default for JsonTreeWrapping {
     fn default() -> Self {
-        // Match defaults of egui::text::TextWrapping.
+        // This disables truncation, makes the text wrap at the UI boundary
+        // and span as many rows as it needs to.
         Self {
             max_rows: usize::MAX,
-            max_width: JsonTreeMaxWidth::Pt(f32::INFINITY),
+            max_width: JsonTreeMaxWidth::UiAvailableWidth,
         }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -92,6 +92,7 @@ impl JsonTreeStyle {
         egui::text::TextWrapping {
             max_width,
             max_rows: wrap.max_rows,
+            break_anywhere: wrap.break_anywhere,
             ..Default::default()
         }
     }
@@ -161,6 +162,7 @@ pub struct JsonTreeWrappingParams {
 pub struct JsonTreeWrapping {
     pub max_rows: usize,
     pub max_width: JsonTreeMaxWidth,
+    pub break_anywhere: bool,
 }
 
 impl Default for JsonTreeWrapping {
@@ -170,6 +172,7 @@ impl Default for JsonTreeWrapping {
         Self {
             max_rows: usize::MAX,
             max_width: JsonTreeMaxWidth::UiAvailableWidth,
+            break_anywhere: false,
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/dmackdev/egui_json_tree/issues/37.

- Adds support for wrapping options for primitive values rendered in the `JsonTree`. `JsonTreeStyle` can be configured with a new `JsonTreeWrappingConfig` to control the wrapping for primitive values in various scenarios and visual states.


See new "Wrapping" demo:
https://github.com/user-attachments/assets/a42c24c5-275a-4dfb-94ac-e0ccfaf989ad