### PR TITLE
add DefaultExpand::SearchResultsOrAll variant

### DIFF
--- a/src/default_expand.rs
+++ b/src/default_expand.rs
@@ -17,4 +17,6 @@ pub enum DefaultExpand<'a> {
     /// and array elements, that match the search term. Letter case is ignored. The matches are highlighted.
     /// If the search term is empty, nothing will be expanded by default.
     SearchResults(&'a str),
+    /// Similar to `SearchResults`, but expands all arrays and objects if the search term is empty.
+    SearchResultsOrAll(&'a str),
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -41,7 +41,9 @@ impl<'a, 'b, T: ToJsonTreeValue> JsonTreeNode<'a, 'b, T> {
             DefaultExpand::All => (InnerExpand::All, None),
             DefaultExpand::None => (InnerExpand::None, None),
             DefaultExpand::ToLevel(l) => (InnerExpand::ToLevel(l), None),
-            DefaultExpand::SearchResults(search_str) => {
+            DefaultExpand::SearchResultsOrAll("") => (InnerExpand::All, None),
+            DefaultExpand::SearchResults(search_str)
+            | DefaultExpand::SearchResultsOrAll(search_str) => {
                 let search_term = SearchTerm::parse(search_str);
                 let search_match_path_ids = search_term
                     .as_ref()


### PR DESCRIPTION
I've added the DefaultExpand::SearchResultsOrAll enum variant to handle my specific needs. I'm not entirely sure what the most ideal implementation would look like, but this appears to be the simplest approach for now :)